### PR TITLE
Removed improper 'to' from Chapter 1 section names.

### DIFF
--- a/chapter1_introduction.html
+++ b/chapter1_introduction.html
@@ -28,7 +28,7 @@
 <p>For this I can only apologize. Programmers can be hostile, macho, arrogant, insecure, and aggressive. There is no excuse for this behaviour. Know that I am on your side. No one <em>gets it</em> at first. Everyone struggles and doubts their abilities. Please don't give up or let the joy be sucked out of the creative experience. Be proud of what you create no matter what it is. People like me don't want you to stop programming. We want to hear your voice, and what you have to say, even if you do not shout as loud as others.<p>
 
 
-<h2>Why to learn C</h2> <hr/>
+<h2>Why learn C</h2> <hr/>
 
 <p>C is one of the most popular and influential programming languages in the world. It is the language of choice for development on Linux, and has been used extensively in the creation of OS X and to some extent Microsoft Windows. It is used on micro-computers too. Your fridge and car probably run on it. In modern software development, the use of C may be escapable, but it's legacy is not. Anyone wanting to make a career out of software development would be smart to learn C.</p>
 
@@ -56,7 +56,7 @@
 <p>This book consists of 16 short chapters. How you complete these is up to you. It may well be possible to blast through this book over a weekend, or to take it more slowly, and do a chapter or two each evening over a week. It shouldn't take very long to complete, and will hopefully leave you with a taste for developing your language further.</p>
 
 
-<h2>Why to build a Lisp</h2> <hr/>
+<h2>Why build a Lisp</h2> <hr/>
 
 <p>The language we are going to be building in this book is a Lisp. This is a family of programming languages characterized by the fact that all their computation is represented by <em>lists</em>. This may sound scarier than it is. Lisps are actually very easy, distinctive, and powerful languages.</p>
 

--- a/contents.html
+++ b/contents.html
@@ -19,9 +19,9 @@
 <ul>
   <li>About</li>
   <li>Who this is for</li>
-  <li>Why to learn C</li>
+  <li>Why learn C</li>
   <li>How to learn C</li>
-  <li>Why to build a Lisp</li>
+  <li>Why build a Lisp</li>
   <li>Your own Lisp</li>
 </ul>
 


### PR DESCRIPTION
Renamed sections "Why to learn C" to "Why learn C" and "Why to build a Lisp" to "Why build a Lisp"

I also believe "Who this is for" would read better as "Who is this for"
