### PR TITLE
Update prompt.c

### DIFF
--- a/src/prompt.c
+++ b/src/prompt.c
@@ -10,7 +10,7 @@ static char buffer[2048];
 
 /* Fake readline function */
 char* readline(char* prompt) {
-  fputs("lispy> ", stdout);
+  fputs(prompt, stdout);
   fgets(buffer, 2048, stdin);
   char* cpy = malloc(strlen(buffer)+1);
   strcpy(cpy, buffer);


### PR DESCRIPTION
The prompt argument for the custom readline function was not being used, was just being hardcoded to "lispy> "
