### PR TITLE
Fixed fake readline

### DIFF
--- a/chapter4_interactive_prompt.html
+++ b/chapter4_interactive_prompt.html
@@ -216,7 +216,7 @@ static char buffer[2048];
 
 /* Fake readline function */
 char* readline(char* prompt) {
-  fputs("lispy> ", stdout);
+  fputs(prompt, stdout);
   fgets(buffer, 2048, stdin);
   char* cpy = malloc(strlen(buffer)+1);
   strcpy(cpy, buffer);


### PR DESCRIPTION
The readline that was implemented before would use `"lispy> "` regardless of the specified prompt.
