### PR TITLE
Fix double free when dividing by zero.

### DIFF
--- a/chapter9_s_expressions.html
+++ b/chapter9_s_expressions.html
@@ -456,7 +456,7 @@ lval* lval_take(lval* v, int i) {
     if (strcmp(op, &quot;*&quot;) == 0) { x-&gt;num *= y-&gt;num; }
     if (strcmp(op, &quot;/&quot;) == 0) {
       if (y-&gt;num == 0) {
-        lval_del(x); lval_del(y); lval_del(a);
+        lval_del(x); lval_del(y);
         x = lval_err(&quot;Division By Zero!&quot;); break;
       } else {
         x-&gt;num /= y-&gt;num;


### PR DESCRIPTION
Reported on #31 
lval_del(a) is called twice when dividing by zero. Removing the lval_del on line 459 since it's called on 471.
