### PR TITLE
Fix double free with lval_del

### DIFF
--- a/src/s_expressions.c
+++ b/src/s_expressions.c
@@ -183,7 +183,7 @@ lval* builtin_op(lval* a, char* op) {
     if (strcmp(op, "*") == 0) { x->num *= y->num; }
     if (strcmp(op, "/") == 0) {
       if (y->num == 0) {
-        lval_del(x); lval_del(y); lval_del(a);
+        lval_del(x); lval_del(y);
         x = lval_err("Division By Zero.");
         break;
       } else {


### PR DESCRIPTION
Reported on #31 
lval_del(a) is called twice when dividing by zero. Removing the lval_del on line 459 since it's called on 471.

Sorry for not putting both these pulls in the same request.
