### PR TITLE
preclude -> precede typo

### DIFF
--- a/chapter7_evaluation.html
+++ b/chapter7_evaluation.html
@@ -23,7 +23,7 @@
 
 <p>This struct has a number of fields we can access. Lets take a look at them one by one.</p>
 
-<p>The first field is <code>tag</code>. When we printed out the tree this was the information that precluded the contents of the node. It was a string containing a list of all the rules used to parse that particular item. For example <code>expr|number|regex</code>.</p>
+<p>The first field is <code>tag</code>. When we printed out the tree this was the information that preceded the contents of the node. It was a string containing a list of all the rules used to parse that particular item. For example <code>expr|number|regex</code>.</p>
 
 <p>This <code>tag</code> field is going to be important as it lets us see what type of thing the node is.</p>
 


### PR DESCRIPTION
I think this is intended to be preceded, rather than precluded.
