### PR TITLE
unindent: Don't use else when we already break

### DIFF
--- a/chapter9_s_expressions.html
+++ b/chapter9_s_expressions.html
@@ -459,9 +459,8 @@ lval* lval_take(lval* v, int i) {
       if (y-&gt;num == 0) {
         lval_del(x); lval_del(y);
         x = lval_err(&quot;Division By Zero!&quot;); break;
-      } else {
-        x-&gt;num /= y-&gt;num;
       }
+      x-&gt;num /= y-&gt;num;
     }
 
     /* Delete element now finished with */

--- a/src/s_expressions.c
+++ b/src/s_expressions.c
@@ -186,9 +186,8 @@ lval* builtin_op(lval* a, char* op) {
         lval_del(x); lval_del(y);
         x = lval_err("Division By Zero.");
         break;
-      } else {
-        x->num /= y->num;
       }
+      x->num /= y->num;
     }
     
     /* Delete element now finished with */


### PR DESCRIPTION
Un-indent the else case, removing the else all together.
This makes for easier reading or the control flow, for easier ammending of more logic (% operator).
The else is not necessary, because we already `break` out of the loop.
