### PR TITLE
Fixed broken tag in ch4

### DIFF
--- a/chapter4_interactive_prompt.html
+++ b/chapter4_interactive_prompt.html
@@ -163,7 +163,7 @@ int main(int argc, char** argv) {
 
 <p>On <strong>Mac</strong> the <code>editline</code> library comes with <em>Command Line Tools</em>. Instructions for installing these can be found in <a href="http://www.buildyourownlisp.com/chapter2_installation">Chapter 2</a>. You may still get an error about the history header not being found. In this case remove the line <code>#include &lt;editline/history.h&gt;</code>, as this header may not be required.</p>
 
-<p>On <strong>Linux</strong> you can install <em>editline</em> with <code>sudo apt-get install libedit-dev</code>. On Fedora or similar you can use the command <code>su -c "yum install libedit-dev*"</code></pre></p>
+<p>On <strong>Linux</strong> you can install <em>editline</em> with <code>sudo apt-get install libedit-dev</code>. On Fedora or similar you can use the command <code>su -c "yum install libedit-dev*"</code></p>
 
 <p>Once you have installed <em>editline</em> you can try to compile it again. This time you'll get a different error.</p>
 


### PR DESCRIPTION
Found an error in the epub in chapter 4. iBooks says "error on line 133 at column 1: Extra content at the end of the document". I don't have the epub source (tho, maybe I do, since this isn't a _normal_ epub), but I tracked down an error in your html file for ch4, so I'm guessing they're related.
