### PR TITLE
updated gdb information URL

### DIFF
--- a/chapter2_installation.html
+++ b/chapter2_installation.html
@@ -101,7 +101,7 @@ int main(int argc, char** argv) {
 
 <p>If you are a beginner, the first port of call for debugging a crashing C program would be to print out lots of information as the program is running. Using this method you should try to isolate exactly what part of the code is incorrect and what, if anything, is going wrong. It is a debugging technique which is <em>active</em>. This is the important thing. As long as you are doing <em>something</em>, and not just staring at the code, the process is less painful and the temptation to give up is lessened.</p>
 
-<p>For people feeling more confident a program called <code>gdb</code> can be used to debug your C programs. This can be difficult and complicated to use, but it is also very powerful and can give you extremely valuable information and what went wrong and where. Information on how to use <code>gdb</code> can be found <a href="http://www.dirac.org/linux/gdb/">online</a>.</p>
+<p>For people feeling more confident a program called <code>gdb</code> can be used to debug your C programs. This can be difficult and complicated to use, but it is also very powerful and can give you extremely valuable information and what went wrong and where. Information on how to use <code>gdb</code> can be found <a href="http://web.archive.org/web/20140910051410/http://www.dirac.org/linux/gdb/">online</a>.</p>
 
 <p>On <strong>Mac</strong> the most recent versions of OS X don't come with <code>gdb</code>. Instead you can use <code>lldb</code> which does largely the same job.</p>
 


### PR DESCRIPTION
gdb tutorial is no longer available in http://www.dirac.org/linux/gdb/, so updated the link with archives.org's URL
