### PR TITLE
Reindenting break statement

### DIFF
--- a/chapter9_s_expressions.html
+++ b/chapter9_s_expressions.html
@@ -218,7 +218,7 @@ lval* lval_sexpr(void) {
       }
       /* Also free the memory allocated to contain the pointers */
       free(v-&gt;cell);
-    break;
+      break;
   }
 
   /* Free the memory allocated for the "lval" struct itself */

--- a/src/s_expressions.c
+++ b/src/s_expressions.c
@@ -86,7 +86,7 @@ void lval_del(lval* v) {
       }
       /* Also free the memory allocated to contain the pointers */
       free(v->cell);
-    break;
+      break;
   }
   
   /* Free the memory allocated for the "lval" struct itself */


### PR DESCRIPTION
The break statements should be indented with the body of the case, since they're evaluated as part of the case body.
