### PR TITLE
Allow setting server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,10 @@ pip install Flask-Mail
 python lispy.py
 ```
 
+You can specify port via `$PORT`.
+
+```
+env PORT=5000 python lispy.py
+```
+
 This will serve the site locally at `http://127.0.0.1:5000/`. You can browse it from there.

--- a/lispy.py
+++ b/lispy.py
@@ -300,5 +300,6 @@ def route_paypal():
 """ Main """
     
 if __name__ == '__main__':
-    app.run()
+    port = int(os.getenv('PORT') or 5000)
+    app.run(port=port)
 


### PR DESCRIPTION
This patch allows for setting port via `$PORT` environment variable. Useful when port 5000 is allocated for something else.