### PR TITLE
Fix a typo

### DIFF
--- a/chapter5_languages.html
+++ b/chapter5_languages.html
@@ -160,7 +160,7 @@ mpc_cleanup(4, Adjective, Noun, Phrase, Doge);
 
 <p>This method of specifying a grammar is what we are going to use in the following chapters. It might seem overwhelming at first. Grammars can be difficult to understand. But as we continue you will become much more familiar with how to create and edit them.</p>
 
-<p>This chapter is about theory, so if you are going to try some of the bonus tasks, don't worry too much about correctness. Thinking in the right mindset is more important. Feel free to invent symbols and notation for certain concepts to make them simpler to write down. Some of the bonus task also might require cyclic or recursive grammar stuctures, so don't worry if you have to use these!</p>
+<p>This chapter is about theory, so if you are going to try some of the bonus tasks, don't worry too much about correctness. Thinking in the right mindset is more important. Feel free to invent symbols and notation for certain concepts to make them simpler to write down. Some of the bonus task also might require cyclic or recursive grammar structures, so don't worry if you have to use these!</p>
 
 
 


### PR DESCRIPTION
`stuctures` → `structures`