### PR TITLE
Provide links directly to sections in table of contents

### DIFF
--- a/chapter10_q_expressions.html
+++ b/chapter10_q_expressions.html
@@ -1,7 +1,7 @@
 <h1>Q-Expressions <small>&bull; Chapter 10</small></h1>
 
 
-<h2>Adding Features</h2> <hr/>
+<h2 id='adding_features'>Adding Features</h2> <hr/>
 
 <p>You'll notice that the following chapters will all follow a similar pattern. This pattern is the typical approach used to add new features to a language. It consists of a number of steps that bring a feature from start to finish. These are listed below, and are exactly what we're going to do in this chapter to introduce a new feature called a Q-Expression.</p>
 
@@ -13,7 +13,7 @@
 </table>
 
 
-<h2>Quoted Expressions</h2> <hr/>
+<h2 id='quoted_expressions'>Quoted Expressions</h2> <hr/>
 
 <p>In this chapter we'll implement a new type of Lisp Value called a Q-Expression.</p>
 
@@ -27,7 +27,7 @@
   <p><strong>I've never heard of Q-Expressions.</strong></p>
 
   <p>Q-Expressions don't exist in other Lisps. Other Lisps use <em>Macros</em> to stop evaluation. These look like normal functions, but they do not evaluate their arguments. A special Macro called quote <code>'</code> exists, which can be used to stop the evaluation of almost anything. This is the inspiration for Q-Expressions, which are unique to our Lisp, and will be used instead of Macros for doing all the same tasks and more.</p>
-  
+
   <p>The way I've used <em>S-Expression</em> and <em>Q-Expression</em> in this book is a slight abuse of terminology, but I hope this misdemeanor makes the behaviour of our Lisp clearer.</p>
 </div>
 
@@ -54,7 +54,7 @@ mpca_lang(MPCA_LANG_DEFAULT,
 <pre><code data-language='c'>mpc_cleanup(6, Number, Symbol, Sexpr, Qexpr, Expr, Lispy);</code></pre>
 
 
-<h2>Reading Q-Expressions</h2> <hr/>
+<h2 id='reading_q-expressions'>Reading Q-Expressions</h2> <hr/>
 
 <p>Because Q-Expressions are so similar S-Expressions much of their internal behaviour is going to be the same. We're going to reuse our S-Expression data fields to represent Q-Expressions, but we still need to add a separate type to the enumeration.</p>
 
@@ -91,7 +91,7 @@ lval* lval_qexpr(void) {
     case LVAL_NUM: break;
     case LVAL_ERR: free(v->err); break;
     case LVAL_SYM: free(v->sym); break;
-    
+
     /* If Qexpr or Sexpr then delete all elements inside */
     case LVAL_QEXPR:
     case LVAL_SEXPR:
@@ -102,7 +102,7 @@ lval* lval_qexpr(void) {
       free(v->cell);
     break;
   }
-  
+
   free(v);
 }
 </code></pre>
@@ -122,7 +122,7 @@ lispy&gt; {{2 3 4} {1}}
 lispy&gt;
 </code></pre>
 
-<h2>Builtin Functions</h2> <hr/>
+<h2 id='builtin_functions'>Builtin Functions</h2> <hr/>
 
 <p>We can read in Q-Expressions but they are still useless. We need some way to manipulate them.</p>
 
@@ -151,8 +151,8 @@ lispy&gt;
   Number, Symbol, Sexpr, Qexpr, Expr, Lispy)
 </code></pre>
 
-  
-<h2>First Attempt</h2> <hr/>
+
+<h2 id='first_attempt'>First Attempt</h2> <hr/>
 
 <p>Our builtin functions should have the same interface as <code>builtin_op</code>. That means the arguments should be bundled into an S-Expression which the function must use and then delete. They should return a new <code>lval*</code> as a result of the evaluation.</p>
 
@@ -170,12 +170,12 @@ lispy&gt;
     lval_del(a);
     return lval_err("Function 'head' passed too many arguments!");
   }
-  
+
   if (a-&gt;cell[0]-&gt;type != LVAL_QEXPR) {
     lval_del(a);
     return lval_err("Function 'head' passed incorrect types!");
   }
-  
+
   if (a-&gt;cell[0]-&gt;count == 0) {
     lval_del(a);
     return lval_err("Function 'head' passed {}!");
@@ -196,12 +196,12 @@ lispy&gt;
     lval_del(a);
     return lval_err("Function 'tail' passed too many arguments!");
   }
-  
+
   if (a-&gt;cell[0]-&gt;type != LVAL_QEXPR) {
     lval_del(a);
     return lval_err("Function 'tail' passed incorrect types!");
-  }  
-  
+  }
+
   if (a-&gt;cell[0]-&gt;count == 0) {
     lval_del(a);
     return lval_err("Function 'tail' passed {}!");
@@ -216,7 +216,7 @@ lispy&gt;
 }</code></pre>
 
 
-<h2>Macros</h2> <hr/>
+<h2 id='macros'>Macros</h2> <hr/>
 
 <div class='pull-right alert alert-warning' style="margin: 15px; text-align: center;">
   <img src="/static/img/strawberry.png" alt="strawberry" class="img-responsive" width="297px" height="200px"/>
@@ -248,7 +248,7 @@ lispy&gt;
   LASSERT(a, a-&gt;cell[0]-&gt;count != 0,
     "Function 'head' passed {}!");
 
-  lval* v = lval_take(a, 0);  
+  lval* v = lval_take(a, 0);
   while (v-&gt;count &gt; 1) { lval_del(lval_pop(v, 1)); }
   return v;
 }
@@ -262,7 +262,7 @@ lispy&gt;
   LASSERT(a, a-&gt;cell[0]-&gt;count != 0,
     "Function 'tail' passed {}!");
 
-  lval* v = lval_take(a, 0);  
+  lval* v = lval_take(a, 0);
   lval_del(lval_pop(v, 0));
   return v;
 }</code></pre>
@@ -322,12 +322,12 @@ lispy&gt;
   }
 
   /* Delete the empty 'y' and return 'x' */
-  lval_del(y);  
+  lval_del(y);
   return x;
 }</code></pre>
 
 
-<h2>Builtins Lookup</h2> <hr/>
+<h2 id='builtins_lookup'>Builtins Lookup</h2> <hr/>
 
 <p>We've now got all of our builtin functions defined. We need to make a function that can call the correct one depending on what symbol it encounters in evaluation. We can do this using <code>strcmp</code> and <code>strstr</code>.</p>
 

--- a/chapter11_variables.html
+++ b/chapter11_variables.html
@@ -1,7 +1,7 @@
 <h1>Variables <small>&bull; Chapter 11</small></h1>
 
 
-<h2>Immutability</h2> <hr/>
+<h2 id='immutability'>Immutability</h2> <hr/>
 
 <div class='pull-right alert alert-warning' style="margin: 15px; text-align: center;">
   <img src="/static/img/turtle.png" alt="turtle" class="img-responsive" width="279px" height="267px"/>
@@ -25,7 +25,7 @@
 </div>
 
 
-<h2>Symbol Syntax</h2> <hr/>
+<h2 id='symbol_syntax'>Symbol Syntax</h2> <hr/>
 
 <p>Now that we're going to allow for user defined variables we need to update the grammar for symbols to be more flexible. Rather than just our builtin functions it should match any possible valid symbol. Unlike in C, where the name a variable can be given is fairly restrictive, we're going to allow for all sorts of characters in the name of a variable.</p>
 
@@ -50,7 +50,7 @@
 </code></pre>
 
 
-<h2>Function Pointers</h2> <hr/>
+<h2 id='function_pointers'>Function Pointers</h2> <hr/>
 
 <p>Once we introduce variables, symbols will no longer represent functions in our language, but rather they will represent a name for us to look up into our environment and get some new value back from.</p>
 
@@ -68,15 +68,15 @@
   <p><strong>Why is that syntax so odd?</strong></p>
 
   <p>In some places the syntax of C can look particularly weird. It can help if we understand exactly why the syntax is like this. Let us de-construct the syntax in the example above part by part.</p>
-  
+
   <p>First the <code>typedef</code>. This can be put before any standard variable declaration. It results in the name of the variable, being declared a new type, matching what would be the inferred type of that variable. This is why in the above declaration what looks like the function name becomes the new type name.</p>
-  
+
   <p>Next all those <code>*</code>. Pointer types in C are actually meant to be written with the star <code>*</code> on the left hand side of the variable name, not the right hand side of the type <code>int *x;</code>. This is because C type syntax works by a kind of inference. Instead of reading <em>"Create a new <code>int</code> pointer <code>x</code>"</em>. It is meant to read <em>"Create a new variable <code>x</code> where to dereference <code>x</code> results in an <code>int</code>."</em> Therefore <code>x</code> is inferred to be a pointer to an <code>int</code>.</p>
-  
+
   <p>This idea is extended to function pointers. We can read the above declaration as follows. <em>"To get an <code>lval*</code> we dereference <code>lbuiltin</code> and call it with a <code>lenv*</code> and a <code>lval*</code>."</em> Therefore <code>lbuiltin</code> must be a function pointer that takes an <code>lenv*</code> and a <code>lval*</code> and returns a <code>lval*</code>.</p>
 </div>
 
-<h2>Cyclic Types</h2> <hr/>
+<h2 id='cyclic_types'>Cyclic Types</h2> <hr/>
 
 <p>The <code>lbuiltin</code> type references the <code>lval</code> type and the <code>lenv</code> type. This means that they should be declared first in the source file.</p>
 
@@ -95,7 +95,7 @@ typedef struct lenv lenv;
 
 /* Lisp Value */
 
-enum { LVAL_ERR, LVAL_NUM,   LVAL_SYM, 
+enum { LVAL_ERR, LVAL_NUM,   LVAL_SYM,
        LVAL_FUN, LVAL_SEXPR, LVAL_QEXPR };
 
 typedef lval*(*lbuiltin)(lenv*, lval*);
@@ -113,7 +113,7 @@ struct lval {
 };</code></pre>
 
 
-<h2>Function Type</h2> <hr/>
+<h2 id='function_type'>Function Type</h2> <hr/>
 
 <p>As we've added a new possible <code>lval</code> type with the enumeration <code>LVAL_FUN</code>. We should update all our relevant functions that work on <code>lvals</code> to deal correctly with this update. In most cases this just means inserting new cases into switch statements.</p>
 
@@ -137,21 +137,21 @@ struct lval {
 <p>We're also going to add a new function for <strong>copying</strong> an <code>lval</code>. This is going to come in useful when we put things into, and take things out of, the environment. For numbers and functions we can just copy the relevant fields directly. For strings we need to copy using <code>malloc</code> and <code>strcpy</code>. To copy lists we need to allocate the correct amount of space and then copy each element individually.</p>
 
 <pre><code data-language='c'>lval* lval_copy(lval* v) {
-  
+
   lval* x = malloc(sizeof(lval));
   x->type = v-&gt;type;
-  
+
   switch (v-&gt;type) {
-    
+
     /* Copy Functions and Numbers Directly */
     case LVAL_FUN: x-&gt;fun = v-&gt;fun; break;
     case LVAL_NUM: x-&gt;num = v-&gt;num; break;
-    
+
     /* Copy Strings using malloc and strcpy */
     case LVAL_ERR:
       x-&gt;err = malloc(strlen(v-&gt;err) + 1);
       strcpy(x-&gt;err, v-&gt;err); break;
-    
+
     case LVAL_SYM:
       x-&gt;sym = malloc(strlen(v-&gt;sym) + 1);
       strcpy(x-&gt;sym, v-&gt;sym); break;
@@ -166,12 +166,12 @@ struct lval {
       }
     break;
   }
-  
+
   return x;
 }</code></pre>
 
 
-<h2>Environment</h2> <hr/>
+<h2 id='environment'>Environment</h2> <hr/>
 
 <p>Our environment structure must encode a list of relationships between <em>names</em> and <em>values</em>. There are many ways to build a structure that can do this sort of thing. We are going to go for the simplest possible method that works well. This is to use two lists of equal length. One is a list of <code>lval*</code>, and the other is a list of <code>char*</code>. Each entry in one list has a corresponding entry in the other list at the same position.</p>
 
@@ -252,7 +252,7 @@ struct lval {
 }</code></pre>
 
 
-<h2>Variable Evaluation</h2> <hr/>
+<h2 id='variable_evaluation'>Variable Evaluation</h2> <hr/>
 
 <p>Our evaluation function now depends on some environment. We should pass this in as an argument and use it to get a value if we encounter a symbol type. Because our environment returns a copy of the value we need to remember to delete the input symbol <code>lval</code>.</p>
 
@@ -273,12 +273,12 @@ struct lval {
   for (int i = 0; i &lt; v-&gt;count; i++) {
     v-&gt;cell[i] = lval_eval(e, v-&gt;cell[i]);
   }
-  
+
   for (int i = 0; i &lt; v-&gt;count; i++) {
     if (v-&gt;cell[i]-&gt;type == LVAL_ERR) { return lval_take(v, i); }
   }
 
-  if (v-&gt;count == 0) { return v; }  
+  if (v-&gt;count == 0) { return v; }
   if (v-&gt;count == 1) { return lval_take(v, 0); }
 
   /* Ensure first element is a function after evaluation */
@@ -295,7 +295,7 @@ struct lval {
 }</code></pre>
 
 
-<h2>Builtins</h2> <hr/>
+<h2 id='builtins'>Builtins</h2> <hr/>
 
 <p>Now that our evaluation relies on the new function type we need to make sure we can register all of our builtin functions with the environment before we start the interactive prompt. At the moment our builtin functions are not the correct type. We need to change their type signature such that they take in some environment, and where appropriate change them to pass this environment into other calls that require it. I won't post the code for this, so go ahead and change the type signatures of the buildin functions to take an <code>lenv*</code> as their first argument now. If you are confused you can look at the sample code for this chapter.</p>
 
@@ -331,7 +331,7 @@ lval* builtin_div(lenv* e, lval* a) {
   lval_del(k); lval_del(v);
 }
 
-void lenv_add_builtins(lenv* e) {  
+void lenv_add_builtins(lenv* e) {
   /* List Functions */
   lenv_add_builtin(e, "list", builtin_list);
   lenv_add_builtin(e, "head", builtin_head);
@@ -355,24 +355,24 @@ while (1) {
 
   char* input = readline("lispy&gt; ");
   add_history(input);
-  
+
   mpc_result_t r;
   if (mpc_parse("&lt;stdin&gt;", input, Lispy, &r)) {
-    
+
     lval* x = lval_eval(e, lval_read(r.output));
     lval_println(x);
     lval_del(x);
-    
+
     mpc_ast_delete(r.output);
-  } else {    
+  } else {
     mpc_err_print(r.error);
     mpc_err_delete(r.error);
   }
-  
+
   free(input);
-  
+
 }
-  
+
 lenv_del(e);
 </code></pre>
 
@@ -391,7 +391,7 @@ Error: unbound symbol!
 lispy&gt;</code></pre>
 
 
-<h2>Define Function</h2> <hr/>
+<h2 id='define_function'>Define Function</h2> <hr/>
 
 <p>We've managed to register our builtins as variables but we still don't have a way for users to define their own variables.</p>
 
@@ -460,7 +460,7 @@ lispy&gt; list a b x y
 lispy&gt;</code></pre>
 
 
-<h2>Error Reporting</h2> <hr/>
+<h2 id='error_reporting'>Error Reporting</h2> <hr/>
 
 <p>So far our error reporting doesn't work so well. We can report when an error occurs, and give a vague notion of what the problem was, but we don't give the user much information about what exactly has gone wrong. For example if there is an unbound symbol we should be able to report exactly which symbol was unbound. This can help the user track down errors, typos, and other trivial problems.</p>
 
@@ -548,7 +548,7 @@ lispy&gt;</code></pre>
   }
 }</code></pre>
 
-<pre><code data-language='c'>LASSERT(a, a-&gt;cell[0]-&gt;type == LVAL_QEXPR, 
+<pre><code data-language='c'>LASSERT(a, a-&gt;cell[0]-&gt;type == LVAL_QEXPR,
   "Function 'head' passed incorrect type for argument 0. "
   "Got %s, Expected %s.",
   ltype_name(a-&gt;cell[0]-&gt;type), ltype_name(LVAL_QEXPR));

--- a/chapter12_functions.html
+++ b/chapter12_functions.html
@@ -1,6 +1,6 @@
 <h1>Functions <small>&bull; Chapter 12</small></h1>
 
-<h2>What is a Function?</h2> <hr/>
+<h2 id='what_is_a_function'>What is a Function?</h2> <hr/>
 
 <p>Functions are the essence of all programming. In the early days of computer science they represented a naive dream. The idea was that we could reduce computation into these smaller and smaller bits of re-usable code. Given enough time, and a proper structure for libraries, eventually we would have written code required for all computational needs. No longer would people have to write their own functions, and programming would consist of an easy job of stitching together components.</p>
 
@@ -51,7 +51,7 @@
 <pre><code data-language='lispy'>add-together 10 20</code></pre>
 
 
-<h2>Function Type</h2> <hr/>
+<h2 id='function_type'>Function Type</h2> <hr/>
 
 <p>To store a function as an <code>lval</code> we need to think exactly what it consists of.</p>
 
@@ -95,14 +95,14 @@
   /* Set Formals and Body */
   v-&gt;formals = formals;
   v-&gt;body = body;
-  return v;  
+  return v;
 }</code></pre>
 
 <p>As with whenever we change our <code>lval</code> type we need to update the functions for <em>deletion</em>, <em>copying</em>, and <em>printing</em> to deal with the changes. For evaluation we'll need to look in greater depth.</p>
 
 <p>For <strong>Deletion</strong>...</p>
 
-<pre><code data-language='c'>case LVAL_FUN: 
+<pre><code data-language='c'>case LVAL_FUN:
   if (!v-&gt;builtin) {
     lenv_del(v-&gt;env);
     lval_del(v-&gt;formals);
@@ -135,7 +135,7 @@ break;</code></pre>
 break;</code></pre>
 
 
-<h2>Lambda Function</h2> <hr/>
+<h2 id='lambda_function'>Lambda Function</h2> <hr/>
 
 <p>We can now add a builtin for our lambda function. We want it to take as input some list of symbols, and a list that represents the code. After that it should return a function <code>lval</code>. We've defined a few of builtins now, and this one will follow the same format. Like in <code>def</code> we do some error checking to ensure the argument types and count are correct (using some newly defined Macros). Then we just pop the first two arguments from the list and pass them to our previously defined function <code>lval_lambda</code>.</p>
 
@@ -144,19 +144,19 @@ break;</code></pre>
   LASSERT_NUM("\\", a, 2);
   LASSERT_TYPE("\\", a, 0, LVAL_QEXPR);
   LASSERT_TYPE("\\", a, 1, LVAL_QEXPR);
-  
+
   /* Check first Q-Expression contains only Symbols */
   for (int i = 0; i &lt; a-&gt;cell[0]-&gt;count; i++) {
     LASSERT(a, (a-&gt;cell[0]-&gt;cell[i]-&gt;type == LVAL_SYM),
       "Cannot define non-symbol. Got %s, Expected %s.",
       ltype_name(a-&gt;cell[0]-&gt;cell[i]-&gt;type),ltype_name(LVAL_SYM));
   }
-  
+
   /* Pop first two arguments and pass them to lval_lambda */
   lval* formals = lval_pop(a, 0);
   lval* body = lval_pop(a, 0);
   lval_del(a);
-  
+
   return lval_lambda(formals, body);
 }</code></pre>
 
@@ -174,7 +174,7 @@ break;</code></pre>
 </div>
 
 
-<h2>Parent Environment</h2> <hr/>
+<h2 id='parent_environment'>Parent Environment</h2> <hr/>
 
 <p>We've given functions their own environment. In this environment we will place the values that their formal arguments are set to. When we come to evaluate the body of the function we can do it in this  environment and know that those variables will have the correct values.</p>
 
@@ -268,38 +268,38 @@ lenv_add_builtin(e, "=",   builtin_put);</code></pre>
 
 <pre><code data-language='c'>lval* builtin_var(lenv* e, lval* a, char* func) {
   LASSERT_TYPE(func, a, 0, LVAL_QEXPR);
-  
+
   lval* syms = a-&gt;cell[0];
   for (int i = 0; i &lt; syms->count; i++) {
     LASSERT(a, (syms-&gt;cell[i]-&gt;type == LVAL_SYM),
       "Function '%s' cannot define non-symbol. "
-      "Got %s, Expected %s.", func, 
+      "Got %s, Expected %s.", func,
       ltype_name(syms-&gt;cell[i]-&gt;type),
       ltype_name(LVAL_SYM));
   }
-  
+
   LASSERT(a, (syms-&gt;count == a-&gt;count-1),
     "Function '%s' passed too many arguments for symbols. "
     "Got %i, Expected %i.", func, syms-&gt;count, a-&gt;count-1);
-    
+
   for (int i = 0; i &lt; syms-&gt;count; i++) {
     /* If 'def' define in globally. If 'put' define in locally */
     if (strcmp(func, "def") == 0) {
       lenv_def(e, syms-&gt;cell[i], a-&gt;cell[i+1]);
     }
-    
+
     if (strcmp(func, "=")   == 0) {
       lenv_put(e, syms-&gt;cell[i], a-&gt;cell[i+1]);
-    } 
+    }
   }
-  
+
   lval_del(a);
   return lval_sexpr();
 }
 </code></pre>
 
 
-<h2>Function Calling</h2> <hr/>
+<h2 id='function_calling'>Function Calling</h2> <hr/>
 
 <p>We need to write the code that runs when an expression gets evaluated and a function <code>lval</code> is called.</p>
 
@@ -323,7 +323,7 @@ lenv_add_builtin(e, "=",   builtin_put);</code></pre>
   f-&gt;env-&gt;par = e;
 
   /* Evaluate the body */
-  return builtin_eval(f-&gt;env, 
+  return builtin_eval(f-&gt;env,
     lval_add(lval_sexpr(), lval_copy(f-&gt;body)));
 }</code></pre>
 
@@ -353,7 +353,7 @@ lenv_add_builtin(e, "=",   builtin_put);</code></pre>
     if (f-&gt;formals-&gt;count == 0) {
       lval_del(a); return lval_err(
         "Function passed too many arguments. "
-        "Got %i, Expected %i.", given, total); 
+        "Got %i, Expected %i.", given, total);
     }
 
     /* Pop the first symbol from the formals */
@@ -420,7 +420,7 @@ lispy&gt; add-mul-ten 50
 lispy&gt;
 </code></pre>
 
-<h2>Variable Arguments</h2> <hr/>
+<h2 id='variable_arguments'>Variable Arguments</h2> <hr/>
 
 <p>We've defined some of our builtin functions so they can take in a variable number of arguments. Functions like <code>+</code> and <code>join</code> can take any number of arguments, and operate on them logically. We should find a way to let user defined functions work on multiple arguments also.</p>
 
@@ -474,7 +474,7 @@ if (f-&gt;formals-&gt;count &gt; 0 &amp;&amp;
 }</code></pre>
 
 
-<h2>Interesting Functions</h2> <hr/>
+<h2 id='interesting_functions'>Interesting Functions</h2> <hr/>
 
 <h3>Function Definition</h3>
 

--- a/chapter13_conditionals.html
+++ b/chapter13_conditionals.html
@@ -1,6 +1,6 @@
 <h1>Conditionals <small>&bull; Chapter 13</small></h1>
 
-<h2>Doing it yourself</h2> <hr/>
+<h2 id='doing_it_yourself'>Doing it yourself</h2> <hr/>
 
 <p>We've come quite far now. Your knowledge of C should be good enough for you to stand on your own feet a little more. If you're feeling confident, this chapter is a perfect opportunity to stretch your wings out and attempt something on your own. It is a fairly short chapter and essentially consists of adding a couple of new builtin functions to deal with comparison and ordering.</p>
 
@@ -14,7 +14,7 @@
 <p>If you still feel uncertain don't worry. Follow along and I'll explain my approach.</p>
 
 
-<h2>Ordering</h2> <hr/>
+<h2 id='ordering'>Ordering</h2> <hr/>
 
 <p>For simplicity's sake I'm going to re-use our number data type to represent the result of comparisons. I'll make a rule similar to C, to say that any number that isn't <code>0</code> evaluates to true in an <code>if</code> statement, while <code>0</code> always evaluates to false.</p>
 
@@ -48,7 +48,7 @@
   LASSERT_NUM(op, a, 2);
   LASSERT_TYPE(op, a, 0, LVAL_NUM);
   LASSERT_TYPE(op, a, 1, LVAL_NUM);
-  
+
   int r;
   if (strcmp(op, "&gt;")  == 0) {
     r = (a-&gt;cell[0]-&gt;num &gt;  a-&gt;cell[1]-&gt;num);
@@ -68,7 +68,7 @@
 </code></pre>
 
 
-<h2>Equality</h2> <hr/>
+<h2 id='equality'>Equality</h2> <hr/>
 
 <p>Equality is going to be different to ordering because we want it to work on more than number types. It will be useful to see if an input is equal to an empty list, or to see if two functions passed in are the same. Therefore we need to define a function which can test for equality between two different types of <code>lval</code>.</p>
 
@@ -93,7 +93,7 @@
       if (x-&gt;builtin || y-&gt;builtin) {
         return x-&gt;builtin == y-&gt;builtin;
       } else {
-        return lval_eq(x-&gt;formals, y-&gt;formals) 
+        return lval_eq(x-&gt;formals, y-&gt;formals)
           &amp;&amp; lval_eq(x-&gt;body, y-&gt;body);
       }
 
@@ -136,7 +136,7 @@ lval* builtin_ne(lenv* e, lval* a) {
 }</code></pre>
 
 
-<h2>If Function</h2> <hr/>
+<h2 id='if_function'>If Function</h2> <hr/>
 
 <p>To make our comparison operators useful we'll need an <code>if</code> function. This function is a little like the ternary operation in C. Upon some condition being true it evaluates to one thing, and if the condition is false, it evaluates to another.</p>
 
@@ -147,12 +147,12 @@ lval* builtin_ne(lenv* e, lval* a) {
   LASSERT_TYPE("if", a, 0, LVAL_NUM);
   LASSERT_TYPE("if", a, 1, LVAL_QEXPR);
   LASSERT_TYPE("if", a, 2, LVAL_QEXPR);
-  
+
   /* Mark Both Expressions as evaluable */
   lval* x;
   a-&gt;cell[1]-&gt;type = LVAL_SEXPR;
   a-&gt;cell[2]-&gt;type = LVAL_SEXPR;
-  
+
   if (a-&gt;cell[0]-&gt;num) {
     /* If condition is true evaluate first expression */
     x = lval_eval(e, lval_pop(a, 1));
@@ -160,7 +160,7 @@ lval* builtin_ne(lenv* e, lval* a) {
     /* Otherwise evaluate second expression */
     x = lval_eval(e, lval_pop(a, 2));
   }
-  
+
   /* Delete argument list and return */
   lval_del(a);
   return x;
@@ -201,7 +201,7 @@ lispy&gt; if (== x y) {+ x y} {- x y}
 </code></pre>
 
 
-<h2>Recursive Functions</h2> <hr/>
+<h2 id='recursive_functions'>Recursive Functions</h2> <hr/>
 
 <p>By introducing conditionals we've actually made our language a lot more powerful. This is because they effectively let us implement recursive functions.</p>
 

--- a/chapter14_strings.html
+++ b/chapter14_strings.html
@@ -1,7 +1,7 @@
 <h1>Strings <small>&bull; Chapter 14</small></h1>
 
 
-<h2>Libraries</h2> <hr/>
+<h2 id='libraries'>Libraries</h2> <hr/>
 
 <div class='pull-right alert alert-warning' style="margin: 15px; text-align: center;">
   <img src="/static/img/string.png" alt="string" class="img-responsive" width="300px" height="219px"/>
@@ -13,13 +13,13 @@
 <p>Every time we update our program and run it again it is annoying having to type in all of our functions. In this chapter we'll add the functionality to load code from a file and run it. This will allow us to start building up a standard library up. Along the way we'll also add support for code comments, strings, and printing.</p>
 
 
-<h2>String Type</h2> <hr/>
+<h2 id='string_type'>String Type</h2> <hr/>
 
 <p>For the user to load a file we'll have to let them supply a string consisting of the file name. Our language supports symbols, but still doesn't support strings, which can include spaces and other characters. We need to add this possible <code>lval</code> type to specify the file names we need.</p>
 
 <p>We start, as in other chapters, by adding an entry to our enum and adding an entry to our <code>lval</code> to represent the type's data.</p>
 
-<pre><code data-language='c'>enum { LVAL_ERR, LVAL_NUM,   LVAL_SYM, LVAL_STR, 
+<pre><code data-language='c'>enum { LVAL_ERR, LVAL_NUM,   LVAL_SYM, LVAL_STR,
        LVAL_FUN, LVAL_SEXPR, LVAL_QEXPR };</code></pre>
 
 <pre><code data-language='c'>/* Basic */
@@ -81,7 +81,7 @@ char* str;
 }</code></pre>
 
 
-<h2>Reading Strings</h2> <hr/>
+<h2 id='reading_strings'>Reading Strings</h2> <hr/>
 
 <p>Now we need to add support for parsing strings. As usual this requires first adding a new grammar rule called <code>string</code> and adding it to our parser.</p>
 
@@ -127,7 +127,7 @@ lispy&gt; eval (head {"hello" "world"})
 lispy&gt;</code></pre>
 
 
-<h2>Comments</h2> <hr/>
+<h2 id='comments'>Comments</h2> <hr/>
 
 <p>While we're building in new syntax to the language we may as well look at comments.</p>
 
@@ -160,8 +160,8 @@ lispy&gt;</code></pre>
 
 <p>And the cleanup function looks like this.</p>
 
-<pre><code data-language='c'>mpc_cleanup(8, 
-  Number, Symbol, String, Comment, 
+<pre><code data-language='c'>mpc_cleanup(8,
+  Number, Symbol, String, Comment,
   Sexpr,  Qexpr,  Expr,   Lispy);</code></pre>
 
 <p>Because comments are only for programmers reading the code, our internal function for reading them in just consists of ignoring them. We can add a clause to deal with them in a similar way to brackets and parenthesis in <code>lval_read</code>.</p>
@@ -171,19 +171,19 @@ lispy&gt;</code></pre>
 <p>Comments won't be of much use on the interactive prompt, but they will be very helpful for adding into files of code to annotate them.</p>
 
 
-<h2>Load Function</h2>
+<h2 id='load_function'>Load Function</h2>
 
 <p>We want to built a function that can load and evaluate a file when passed a string of its name. To implement this function we'll need to make use of our grammar as we'll need it to to read in the file contents, parse, and evaluate them. Our load function is going to rely on our <code>mpc_parser*</code> called <code>Lispy</code>.</p>
 
 <p>Therefore, just like with functions, we need to forward declare our parser pointers, and place them at the top of the file.</p>
 
-<pre><code data-language='c'>mpc_parser_t* Number; 
-mpc_parser_t* Symbol; 
-mpc_parser_t* String; 
+<pre><code data-language='c'>mpc_parser_t* Number;
+mpc_parser_t* Symbol;
+mpc_parser_t* String;
 mpc_parser_t* Comment;
-mpc_parser_t* Sexpr;  
-mpc_parser_t* Qexpr;  
-mpc_parser_t* Expr; 
+mpc_parser_t* Sexpr;
+mpc_parser_t* Qexpr;
+mpc_parser_t* Expr;
 mpc_parser_t* Lispy;
 </code></pre>
 
@@ -196,11 +196,11 @@ mpc_parser_t* Lispy;
 <pre><code data-language='c'>lval* builtin_load(lenv* e, lval* a) {
   LASSERT_NUM("load", a, 1);
   LASSERT_TYPE("load", a, 0, LVAL_STR);
-  
+
   /* Parse File given by string name */
   mpc_result_t r;
   if (mpc_parse_contents(a-&gt;cell[0]-&gt;str, Lispy, &r)) {
-    
+
     /* Read contents */
     lval* expr = lval_read(r.output);
     mpc_ast_delete(r.output);
@@ -212,31 +212,31 @@ mpc_parser_t* Lispy;
       if (x-&gt;type == LVAL_ERR) { lval_println(x); }
       lval_del(x);
     }
-    
+
     /* Delete expressions and arguments */
-    lval_del(expr);    
+    lval_del(expr);
     lval_del(a);
-    
+
     /* Return empty list */
     return lval_sexpr();
-    
+
   } else {
     /* Get Parse Error as String */
     char* err_msg = mpc_err_string(r.error);
     mpc_err_delete(r.error);
-    
+
     /* Create new error message using it */
     lval* err = lval_err("Could not load Library %s", err_msg);
     free(err_msg);
     lval_del(a);
-    
+
     /* Cleanup and return error */
     return err;
   }
 }</code></pre>
 
 
-<h2>Command Line Arguments</h2> <hr/>
+<h2 id='command_line_arguments'>Command Line Arguments</h2> <hr/>
 
 <p>With the ability to load files, we can take the chance to add in some functionality typical of other programming languages. When file names are given as arguments to the command line we can try to run these files. For example to run a python file one might write <code>python filename.py</code>.</p>
 
@@ -268,7 +268,7 @@ if (argc &gt;= 2) {
 <pre><code>lispy example.lspy</code></pre>
 
 
-<h2>Print Function</h2> <hr/>
+<h2 id='print_function'>Print Function</h2> <hr/>
 
 <p>If we are running programs from the command line we might want them to output some data, rather than just define functions and other values. We can add a <code>print</code> function to our Lisp which makes use of our existing <code>lval_print</code> function.</p>
 
@@ -289,7 +289,7 @@ if (argc &gt;= 2) {
 }</code></pre>
 
 
-<h2>Error Function</h2> <hr/>
+<h2 id='error_function'>Error Function</h2> <hr/>
 
 <p>We can also make use of strings to add in an error reporting function. This can take as input a user supplied string and provide it as an error message for <code>lval_err</code>.</p>
 
@@ -308,7 +308,7 @@ if (argc &gt;= 2) {
 <p>The final step is to register these as builtins. Now finally we can start building up libraries and writing them to files.</p>
 
 <pre><code data-language='c'>/* String Functions */
-lenv_add_builtin(e, "load",  builtin_load); 
+lenv_add_builtin(e, "load",  builtin_load);
 lenv_add_builtin(e, "error", builtin_error);
 lenv_add_builtin(e, "print", builtin_print);
 </code></pre>
@@ -325,7 +325,7 @@ lispy&gt;
 </code></pre>
 
 
-<h2>Finishing Up</h2> <hr/>
+<h2 id='finishing_up'>Finishing Up</h2> <hr/>
 
 <p>This is the last chapter in which we are going to explicitly work on our C implementation of Lisp. The result of this chapter will be the final state of your language implementation.</p>
 

--- a/chapter15_standard_library.html
+++ b/chapter15_standard_library.html
@@ -1,6 +1,6 @@
 <h1>Standard Library <small>&bull; Chapter 15</small></h1>
 
-<h2>Minimalism</h2> <hr/>
+<h2 id='minimalism'>Minimalism</h2> <hr/>
 
 <div class='pull-right alert alert-warning' style="margin: 15px; text-align: center;">
   <img src="/static/img/library.png" alt="library" class="img-responsive" width="299px" height="444px"/>
@@ -12,7 +12,7 @@
 <p>The motivation behind minimalism is two-fold. The first advantage is that it makes the core language simple to debug and easy to learn. This is a great benefit to developers and users. Like <a href="http://en.wikipedia.org/wiki/Occam%27s_razor">Occam's Razor</a> it is almost always better to trim away any waste if it results in a equally expressive language. The second reason is that having a small language is also aesthetically nicer. It is clever, interesting and fun to see how small we can make the core of a language, and still get something useful out of the other side. As hackers, which we should be by now, this is something we enjoy.</p>
 
 
-<h2>Atoms</h2> <hr/>
+<h2 id='atoms'>Atoms</h2> <hr/>
 
 <p>When dealing with conditionals we added no new boolean type to our language. Because of this we didn't add <code>true</code> or <code>false</code> either. Instead we just used numbers. Readability is still important though, so we can define some constants to represent these values.</p>
 
@@ -27,7 +27,7 @@
 (def {false} 0)</code></pre>
 
 
-<h2>Building Blocks</h2> <hr/>
+<h2 id='building_blocks'>Building Blocks</h2> <hr/>
 
 <p>We've already come up with a number of cool functions I've been using in the examples. One of these is our <code>fun</code> function that allows us to declare functions in a neater way. We should definitely include this in our standard library.</p>
 
@@ -78,7 +78,7 @@ Error: Unbound Symbol 'x'
 lispy&gt;</code></pre>
 
 
-<h2>Logical Operators</h2> <hr/>
+<h2 id='logical_operators'>Logical Operators</h2> <hr/>
 
 <p>We didn't define any local operators such as <code>and</code> and <code>or</code> in our language. This might be a good thing to add in later. For now we can use arithmetic operators to emulate them. Think about how these functions work when encountering <code>0</code> or <code>1</code> for their various inputs.</p>
 
@@ -88,7 +88,7 @@ lispy&gt;</code></pre>
 (fun {and x y} {* x y})</code></pre>
 
 
-<h2>Miscellaneous Functions</h2> <hr/>
+<h2 id='miscellaneous_functions'>Miscellaneous Functions</h2> <hr/>
 
 <p>Here are a couple of miscellaneous functions that don't really fit in anywhere. See if you can guess their intended functionality.</p>
 
@@ -137,7 +137,7 @@ lispy&gt;
 </code></pre>
 
 
-<h2>List Functions</h2> <hr/>
+<h2 id='list_functions'>List Functions</h2> <hr/>
 
 <p>The <code>head</code> function is used to get the first element of a list, but what it returns is still wrapped in the list. If we want to actually get the element out of this list we need to extract it somehow.</p>
 
@@ -251,7 +251,7 @@ lispy&gt;</code></pre>
 (fun {product l} {foldl * 1 l})</code></pre>
 
 
-<h2>Conditional Functions</h2> <hr/>
+<h2 id='conditional_functions'>Conditional Functions</h2> <hr/>
 
 <p>By defining our <code>fun</code> function we've already shown how powerful our language is in its ability to define functions that look like new syntax. Another example of this is found in emulating the C <code>switch</code> and <code>case</code> statements. In C these are built into the language, but for our language we can define them as part of a library.</p>
 
@@ -300,7 +300,7 @@ lispy&gt;</code></pre>
 })</code></pre>
 
 
-<h2>Fibonacci</h2> <hr/>
+<h2 id='fibonacci'>Fibonacci</h2> <hr/>
 
 <p>No standard library would be complete without an obligatory definition of the Fibonacci function. Using all of the above things we've defined  we can write a cute little <code>fib</code> function that is really quite readable, and clear semantically.</p>
 

--- a/chapter16_bonus_projects.html
+++ b/chapter16_bonus_projects.html
@@ -1,21 +1,21 @@
 <h1>Bonus Projects <small>&bull; Chapter 16</small></h1>
 
 
-<h2>Only the Beginning</h2> <hr/>
+<h2 id='only_the_beginning'>Only the Beginning</h2> <hr/>
 
 <p>Although we've done a lot with our Lisp, it is still some way off from a fully complete, production-strength programming language. If you tried to use it for any sufficiently large project there are a number of issues you would eventually run into and improvements you'd have to make. Solving these problems would be what would bring it more into the scope of a fully fledged programming language.</p>
 
 <p>Here are some of these issues you would likely encounter, potential solutions to these problems, and some other fun ideas for other improvements. Some may take a few hundred lines of code, others a few thousand. The choice of what to tackle is up to you. If you've become fond of your language you may enjoy doing some of these projects.</p>
 
 
-<h2>Native Types</h2> <hr/>
+<h2 id='native_types'>Native Types</h2> <hr/>
 
 <p>Currently our language only wraps the native C <code>long</code> and <code>char*</code> types. This is pretty limiting if you want to do any kind of useful computation. Our operations on these data types are also pretty limited. Ideally our language should wrap all of the native C types and allow for methods of manipulating them. One of the most important additions would be the ability to manipulate decimal numbers. For this you could wrap the <code>double</code> type and relevant operations. With more than one number type we need to make sure the arithmetic operators such as <code>+</code> and <code>-</code> work on them all, and them in combination.</p>
 
 <p>Adding support for native types should be interesting for people wishing to do computation with decimal and floating-point numbers in their language.</p>
 
 
-<h2>User Defined Types</h2> <hr/>
+<h2 id='user_defined_types'>User Defined Types</h2> <hr/>
 
 <p>As well as adding support for native types it would be good to give users the ability to add their own new types, just like how we use structs in C. The syntax or method you use to do this would be up to you. This is a really essential part making our language usable for any reasonably sized project.</p>
 
@@ -27,14 +27,14 @@
   <p><small>Important List &bull; Play! BE HAPPY and go home.</small></p>
 </div>
 
-<h2>List Literal</h2> <hr/>
+<h2 id='list_literal'>List Literal</h2> <hr/>
 
 <p>Some lisps use square brackets <code>[]</code> to give a literal notation for lists of evaluated values lists. This syntactic sugar for writing something like <code>list 100 (+ 10 20) 300</code>. Instead it lets you write <code>[100 (+ 10 20) 300]</code>. In some situations this is clearly nicer, but it does use up the <code>[]</code> characters which could possibly be used for more interesting purposes.</p>
 
 <p>This should be a simple addition for people looking to try out adding extra syntax.</p>
 
 
-<h2>Operating System Interaction</h2> <hr/>
+<h2 id='operating_system_interaction'>Operating System Interaction</h2> <hr/>
 
 <p>One essential part of bootstrapping a language is to give it proper abilities for opening, reading, and writing files. This means wrapping all the C functions such as <code>fread</code>, <code>fwrite</code>, <code>fgetc</code>, etc in Lisp equivalents. This is a fairly straight forward task, but does require writing quite a large number of wrapper functions. This is why we've not done it for our language so far.</p>
 
@@ -43,7 +43,7 @@
 <p>People who wish to make use of their language for doing simple scripting tasks and string manipulation may be interested in implementing this project.</p>
 
 
-<h2>Macros</h2> <hr/>
+<h2 id='macros'>Macros</h2> <hr/>
 
 <p>Many other Lisps allow you to write things like <code>(def x 100)</code> to define the value <code>100</code> to <code>x</code>. In our lisp this wouldn't work because it would attempt to evaluate the <code>x</code> to whatever value was stored as <code>x</code> in the environment. In other Lisps these functions are called <em>macros</em>, and when encountered they stop the evaluation of their arguments, and manipulate them un-evaluated. They let you write things that look like normal function calls, but actually do complex and interesting things.</p>
 
@@ -52,16 +52,16 @@
 <p>I like how our language handles things like <code>def</code> and <code>if</code> without resorting to macros, but if you dislike how it works currently, and want it to be more similar to conventional Lisps, this might be something you are interested in implementing.</p>
 
 
-<h2>Variable Hashtable</h2> <hr/>
+<h2 id='variable_hashtable'>Variable Hashtable</h2> <hr/>
 
 <p>At the moment when we lookup variable names in our language we just do a linear search over all of the variables in the environment. This gets more and more inefficient the more variables we have defined.</p>
 
 <p>A more efficient way to do this is to implement a <em>Hash Table</em>. This technique converts the variable name to an integer and uses this to index into an array of a known size to find the value associated with this symbol. This is a really important data structure in programming and will crop up everywhere because of its fantastic performance under heavy loads.</p>
 
-<p>Anyone who is interested in learning more about data structures and algorithms would be smart to take a shot at implementing this data structure or one of its variations.</p> 
+<p>Anyone who is interested in learning more about data structures and algorithms would be smart to take a shot at implementing this data structure or one of its variations.</p>
 
 
-<h2>Pool Allocation</h2> <hr/>
+<h2 id='pool_allocation'>Pool Allocation</h2> <hr/>
 
 <p>Our Lisp is very simple, it is not fast. Its performance is relative to some scripting languages such as Python and Ruby. Most of the performance overhead in our program comes from the fact that doing almost anything requires us to construct and destruct <code>lval</code>. We therefore call <code>malloc</code> very often. This is a slow function as it requires the operating system to do some management for us. When doing calculations there is lots of copying, allocation and deallocation of <code>lval</code> types.</p>
 
@@ -70,7 +70,7 @@
 <p>This can be tricky to implement correctly, but conceptually does not need to be complex. If you want a quick method for getting large gains in performance, looking into this might interest you.</p>
 
 
-<h2>Garbage Collection</h2> <hr/>
+<h2 id='garbage_collection'>Garbage Collection</h2> <hr/>
 
 <p>Almost all other implementations of Lisps assign variables differently to ours. They do not store a copy of a value in the environment, but actually a pointer, or reference, to it directly. Because pointers are used, rather than copies, just like in C, there is much less overhead required when using large data structures.</p>
 
@@ -86,7 +86,7 @@
 <p>This should interest anyone who is concerned with the language's performance and wishes to change the semantics of how variables are stored and modified in the language.</p>
 
 
-<h2>Tail Call Optimisation</h2> <hr/>
+<h2 id='tail_call_optimisation'>Tail Call Optimisation</h2> <hr/>
 
 <p>Our programming language uses <em>recursion</em> to do its looping. This is conceptually a really clever way to do it, but practically it is quite poor. Recursive functions call themselves to collect all of the partial results of a computation, and only then combine all the results together. This is a wasteful way of doing computation when partial results can be accumulated as some total over a loop. This is particularly problematic for loops that are intended to run for many, or infinite, iterations.</p>
 
@@ -95,7 +95,7 @@
 <p>People who are interested in compiler optimisations and the correspondences between different forms of computation might find this project interesting.</p>
 
 
-<h2>Lexical Scoping</h2> <hr/>
+<h2 id='lexical_scoping'>Lexical Scoping</h2> <hr/>
 
 <p>When our language tries to lookup a variable that has been undefined it throws an error. It would be better if it could tell us which variables are undefined before evaluating the program. This would let us avoid typos and other annoying bugs. Finding these issues before the program is run is called <em>lexical scoping</em>, and uses the rules for variable definition to try and infer which variables are defined and which aren't at each point in the program, without doing any evaluation.</p>
 
@@ -107,14 +107,14 @@
   <p><small>Static Electricity &bull; A hair-raising alternative.</small></p>
 </div>
 
-<h2>Static Typing</h2> <hr/>
+<h2 id='static_typing'>Static Typing</h2> <hr/>
 
 <p>Every value in our program has an associated type with it. This we know before any evaluation has taken place. Our builtin functions also only take certain types as input. We should be able to use this information to infer the types of new user defined functions and values. We can also use this information to check that functions are being called with the correct types before we run the program. This will reduce any errors stemming from calling functions with incorrect types before evaluation. This checking is called <em>static typing</em>.</p>
 
 <p>Type systems are a really interesting and fundamental part of computer science. They are currently the best method we know of detecting errors before running a program. Anyone interesting in programming language safety and type systems should find this project really interesting.</p>
 
 
-<h2>Conclusion</h2> <hr/>
+<h2 id='conclusion'>Conclusion</h2> <hr/>
 
 <p>Many thanks for reading this book. I hope you've found something of interest in its pages. If you did enjoy it please tell your friends about it. If you are going to continue developing your language then best of luck and I hope you learn many more things about C, programming languages, and computer science.</p>
 

--- a/chapter1_introduction.html
+++ b/chapter1_introduction.html
@@ -1,7 +1,7 @@
 <h1>Introduction <small>&bull; Chapter 1</small></h1>
 
 
-<h2>About</h2> <hr/>
+<h2 id='about'>About</h2> <hr/>
 
 <p>In this book you'll learn the C programming language and at the same time learn how to build <em>your very own programming language</em>, a minimal Lisp, in under 1000 lines of code! We'll be using a library to do some of the initial work, so I'm cheating a bit on the line count, but the rest of the code will be completely original, and you really will create a powerful little Lisp by the end.</p>
 
@@ -10,7 +10,7 @@
 <p>Many people are keen to learn C, but have nowhere to start. Now there is no excuse. If you follow this book I can promise that, in the worst case, you'll get a cool new programming language to play with, and hopefully you'll become an experienced C programmer too!</p>
 
 
-<h2>Who this is for</h2> <hr/>
+<h2 id='who_this_is_for'>Who this is for</h2> <hr/>
 
 <p>This book is for anyone wanting to learn C, or who has once wondered how to build their own programming language. This book is not suitable as a first programming language book, but anyone with some minimal programming experience, in any language, should find something new and interesting inside. </p>
 
@@ -28,7 +28,7 @@
 <p>For this I can only apologise. Programmers can be hostile, macho, arrogant, insecure, and aggressive. There is no excuse for this behaviour. Know that I am on your side. No one <em>gets it</em> at first. Everyone struggles and doubts their abilities. Please don't give up or let the joy be sucked out of the creative experience. Be proud of what you create no matter what it is. People like me don't want you to stop programming. We want to hear your voice, and what you have to say.</p>
 
 
-<h2>Why learn C</h2> <hr/>
+<h2 id='why_learn_c'>Why learn C</h2> <hr/>
 
 <p>C is one of the most popular and influential programming languages in the world. It is the language of choice for development on Linux, and has been used extensively in the creation of OS X and to some extent Microsoft Windows. It is used on micro-computers too. Your fridge and car probably run on it. In modern software development, the use of C may be escapable, but its legacy is not. Anyone wanting to make a career out of software development would be smart to learn C.</p>
 
@@ -47,7 +47,7 @@
 
 <p>To want to master C is to care about what is powerful, clever, and free. To become a programmer with all the vast powers of technology at his or her fingertips and the responsibility to do something to benefit the world.</p>
 
-<h2>How to learn C</h2> <hr/>
+<h2 id='how_to_learn_c'>How to learn C</h2> <hr/>
 
 <p>There is no way around the fact that C is a difficult language. It has many concepts that are unfamiliar, and it makes no attempts to help a new user. In this book I am <em>not</em> going to cover in detail things like the syntax of the language, or how to write loops and conditional statements.</p>
 
@@ -56,7 +56,7 @@
 <p>This book consists of 16 short chapters. How you complete these is up to you. It may well be possible to blast through this book over a weekend, or to take it more slowly and do a chapter or two each evening over a week. It shouldn't take very long to complete, and will hopefully leave you with a taste for developing your language further.</p>
 
 
-<h2>Why build a Lisp</h2> <hr/>
+<h2 id='why_build_a_lisp'>Why build a Lisp</h2> <hr/>
 
 <p>The language we are going to be building in this book is a Lisp. This is a family of programming languages characterised by the fact that all their computation is represented by <em>lists</em>. This may sound scarier than it is. Lisps are actually very easy, distinctive, and powerful languages.</p>
 
@@ -65,7 +65,7 @@
   <p><small>Mike Tyson &bull; Your typical Lisp user</small></p>
 </div>
 
-<p>Building a Lisp is a great project for so many reasons. It puts you in the shoes of language designers, and gives you an appreciation for the whole process of programming, from language all the way down to machine. It teaches you about functional programming, and novel ways to view computation. The final product you are rewarded with provides a template for future thoughts and developments, giving you a starting ground for trying new things. It simply isn't possible to comprehend the creativity and cleverness that goes into programming and computer science until you explore languages themselves.</p> 
+<p>Building a Lisp is a great project for so many reasons. It puts you in the shoes of language designers, and gives you an appreciation for the whole process of programming, from language all the way down to machine. It teaches you about functional programming, and novel ways to view computation. The final product you are rewarded with provides a template for future thoughts and developments, giving you a starting ground for trying new things. It simply isn't possible to comprehend the creativity and cleverness that goes into programming and computer science until you explore languages themselves.</p>
 
 <p>The type of Lisp we'll be building is one I've invented for the purposes of this book. I've designed it for minimalism, simplicity and clarity, and I've become quite fond of it along the way. I hope you come to like it too. Conceptually, syntactically, and in implementation, this Lisp has a number of differences to other major brands of Lisp. So much so that I'm sure I will be getting e-mails from Lisp programmers telling me it <em>isn't a Lisp</em> because it <em>doesn't do/have/look-like this or that</em>.</p>
 
@@ -74,7 +74,7 @@
 <p>If you are looking to learn about the semantics and behaviours of conventional Lisps, and how to program them, this book may not be for you. What this book offers instead is new and unique concepts, self expression, creativity, and fun. Whatever your motivation, heed this disclaimer now. Not everything I say will be objectively correct or true! You will have to decide that for yourselves.</p>
 
 
-<h2>Your own Lisp</h2> <hr/>
+<h2 id='your_own_lisp'>Your own Lisp</h2> <hr/>
 
 <p>The best way to follow this book is to, as the title says, write <em>your own</em> Lisp. If you are feeling confident enough I want you to add your own features, modifications and changes. Your Lisp should suit you and your own philosophy. Throughout the book I'll be giving description and insight, but with it I'll be providing <em>a lot</em> of code. This will make it easy to follow along by copy and pasting each section into your program without really understanding. <em>Please do not do this!</em>.</p>
 
@@ -92,4 +92,3 @@
     <td class="text-right"><a href="chapter2_installation"><h4>Installation &rsaquo;</h4></a></td>
   </tr>
 </table>
-

--- a/chapter2_installation.html
+++ b/chapter2_installation.html
@@ -1,7 +1,7 @@
 <h1>Installation <small>&bull; Chapter 2</small></h1>
 
 
-<h2>Setup</h2> <hr/>
+<h2 id='setup'>Setup</h2> <hr/>
 
 <div class='pull-right alert alert-warning' style="margin: 15px; text-align: center;">
   <img src="/static/img/cattop.png" alt="capttop" class="img-responsive" width="297px" height="461px"/>
@@ -11,7 +11,7 @@
 <p>Before we can start programming in C we'll need to install a couple of things, and set up our environment so that we have everything we need. Because C is such a universal language this should hopefully be fairly simple. Essentially we need to install two main things. A <em>text editor</em> and a <em>compiler</em>.</p>
 
 
-<h2>Text Editor</h2> <hr/>
+<h2 id='text_editor'>Text Editor</h2> <hr/>
 
 <p>A text editor is a program that allows you to edit text files in a way suitable for programming.</p>
 
@@ -22,7 +22,7 @@
 <p>On <strong>Windows</strong> my text editor of choice is <a href="http://notepad-plus-plus.org/">Notepad++</a>. If you have another preference this is fine. Please <em>don't</em> use <em>Visual Studio</em> as it does not have proper support for C programming. If you attempt to use it you will run into many problems.</p>
 
 
-<h2>Compiler</h2> <hr/>
+<h2 id='compiler'>Compiler</h2> <hr/>
 
 <p>The compiler is a program that transforms the C source code into a program your computer can run. The installation process for these is different depending on what operating system you are running.</p>
 
@@ -35,7 +35,7 @@
 <p>On <strong>Windows</strong> you can install a compiler by downloading and installing <a href="http://www.mingw.org/">MinGW</a>. If you use the installer at some point it may present you with a list of possible packages. Make sure you pick at least <code>mingw32-base</code> and <code>msys-base</code>. Once installed you need to add the compiler and other programs to your system <code>PATH</code> variable. To do this follow <a href="http://www.computerhope.com/issues/ch000549.htm">these instructions</a> appending the value <code>;C:\MinGW\bin</code> to the variable called <code>PATH</code>. You can create this variable if it doesn't exist. You may need to restart <code>cmd.exe</code> for the changes to take effect. This will allow you to run a compiler from the command line <code>cmd.exe</code>. It will also install other programs which make <code>cmd.exe</code> act like a Unix command line.</p>
 
 
-<h3>Testing the Compiler</h3>
+<h3 id='testing_the_compiler'>Testing the Compiler</h3>
 
 <p>To test if your C compiler is installed correctly type the following into the command line.</p>
 
@@ -44,7 +44,7 @@
 <p>If you get some information about the compiler version echoed back then it should be installed correctly. You are ready to go! If you get any sort of error message about an unrecognised or not found command, then it is not ready. You may need to restart the command line or your computer for changes to take effect.</p>
 
 
-<h2>Hello World</h2> <hr/>
+<h2 id='hello_world'>Hello World</h2> <hr/>
 
 <p>Now that your environment is set up, start by opening your text editor and inputting the following program. Create a directory where you are going to put your work for this book, and save this file as <code>hello_world.c</code>. This is your first C program!</p>
 
@@ -71,7 +71,7 @@ int main(int argc, char** argv) {
 <p>Inside <code>main</code> the <code>puts</code> function is <em>called</em> with the argument <code>"Hello, world!"</code>. This outputs the message <code>Hello, world!</code> to the command line. The function <code>puts</code> is short for <em>put string</em>. The second statement inside the function is <code>return 0;</code>. This tells the <code>main</code> function to finish and return <code>0</code>. When a C program returns <code>0</code> this indicates there have been no errors running the program.</p>
 
 
-<h2>Compilation</h2> <hr/>
+<h2 id='compilation'>Compilation</h2> <hr/>
 
 <p>Before we can run this program we need to compile it. This will produce the actual <em>executable</em> we can run on our computer. Open up the command line and browse to the directory that <code>hello_world.c</code> is saved in. You can then compile your program using the following command.</p>
 
@@ -84,7 +84,7 @@ int main(int argc, char** argv) {
 <p><strong>Congratulations!</strong> You've just compiled and run your first C program.</p>
 
 
-<h2>Errors</h2> <hr/>
+<h2 id='errors'>Errors</h2> <hr/>
 
 <p>If there are some problems with your C program the compilation process may fail. These issues can range from simple syntax errors, to other complicated problems that are harder to understand.</p>
 
@@ -108,7 +108,7 @@ int main(int argc, char** argv) {
 <p>On <strong>Linux</strong> or <strong>Mac</strong> <code>valgrind</code> can be used to aid the debugging of memory leaks and other more nasty errors. Valgrind is a tool that can save you hours, or even days, of debugging. It does not take much to get proficient at it, so investigating it is highly recommended. Information on how to use it can be found <a href="http://www.cprogramming.com/debugging/valgrind.html">online</a>.</p>
 
 
-<h2>Documentation</h2> <hr/>
+<h2 id='documentation'>Documentation</h2> <hr/>
 
 <p>Through this book you may come across a function in some example code that you don't recognise. You might wonder what it does. In this case you will want to look at the <a href="http://en.cppreference.com/w/c">online documentation</a> of the standard library. This will explain all the functions included in the standard library, what they do, and how to use them.</p>
 
@@ -117,7 +117,7 @@ int main(int argc, char** argv) {
 
 <div class="alert alert-warning">
   <p><strong>What is this section for?</strong></p>
-  
+
   <p>In this section I'll link to the code I've written for this particular chapter of the book. When finishing with a chapter your code should probably look similar to mine. This code can be used for reference if the explanation has been unclear.</p>
 
   <p>If you encounter a bug please do not copy and paste my code into your project. Try to track down the bug yourself and use my code as a reference to highlight what may be wrong, or where the error may lie.</p>
@@ -136,7 +136,7 @@ int main(int argc, char** argv) {
 
   <p>Many will require some research on the internet. This is an integral part of learning a new language so should not be avoided. The ability to teach yourself things is one of the most valuable skills in programming.</p>
 </div>
-  
+
 <div class="alert alert-warning">
   <ul class="list-group">
     <li class="list-group-item">&rsaquo; Change the <code>Hello World!</code> greeting given by your program to something different.</li>

--- a/chapter3_basics.html
+++ b/chapter3_basics.html
@@ -1,7 +1,7 @@
 <h1>Basics <small>&bull; Chapter 3</small></h1>
 
 
-<h2>Overview</h2> <hr/>
+<h2 id='overview'>Overview</h2> <hr/>
 
 <div class='pull-right alert alert-warning' style="margin: 15px; text-align: center;">
   <img src="/static/img/programs.png" alt="programs" class="img-responsive" width="251px" height="410px"/>
@@ -13,7 +13,7 @@
 <p>The goal of this chapter is to get everyone on the same page. People totally new to C should therefore take some time over it, while those with some existing experience may find it easier to skim and return to later as required.</p>
 
 
-<h2>Programs</h2> <hr/>
+<h2 id='programs'>Programs</h2> <hr/>
 
 <p>A program in C consists of only <em>function definitions</em> and <em>structure definitions</em>.</p>
 
@@ -24,13 +24,13 @@
 <p>As we saw in the previous chapter, the execution of a C program always starts in the function called <code>main</code>. From here it calls more and more functions, to perform all the actions it requires.</p>
 
 
-<h2>Variables</h2> <hr/>
+<h2 id='variables'>Variables</h2> <hr/>
 
 <p>Functions in C consist of manipulating <em>variables</em>. These are items of data which we give a name to.</p>
 
 <p>Every variable in C has an explicit <em>type</em>. These types are declared by ourselves or built into the language. We can declare a new variable by writing the name of its type, followed by its name, and optionally setting it to some value using <code>=</code>. This declaration is a <em>statement</em>, and we terminate all <em>statements</em> in C with a semicolon <code>;</code>.</p>
 
-<p>To create a new <code>int</code> called <code>count</code> we could write the following...</p> 
+<p>To create a new <code>int</code> called <code>count</code> we could write the following...</p>
 
 <pre><code data-language='c'>int count;</code></pre>
 
@@ -50,7 +50,7 @@
 </table>
 
 
-<h2>Function Declarations</h2> <hr/>
+<h2 id='function_declarations'>Function Declarations</h2> <hr/>
 
 <p>A function is a computation that manipulates variables, and optionally changes the state of the program. It takes as input some variables and returns some single variable as output.</p>
 
@@ -68,7 +68,7 @@
 <pre><code data-language='c'>int added = add_together(10, 18);</code></pre>
 
 
-<h2>Structure Declarations</h2> <hr/>
+<h2 id='structure_declarations'>Structure Declarations</h2> <hr/>
 
 <p>Structures are used to declare new <em>types</em>. Structures are several variables bundled together into a single package.</p>
 
@@ -91,7 +91,7 @@ float length = sqrt(p.x * p.x + p.y * p.y);
 
 
 
-<h2>Pointers</h2> <hr/>
+<h2 id='pointers'>Pointers</h2> <hr/>
 
 <div class='pull-right alert alert-warning' style="margin: 15px; text-align: center;">
   <img src="/static/img/pointer.png" alt="pointer" class="img-responsive" width="251px" height="384px"/>
@@ -103,14 +103,14 @@ float length = sqrt(p.x * p.x + p.y * p.y);
 <p>Pointers are used for a whole number of different things such as for strings or lists. These are a difficult part of C and will be explained in much greater detail in later chapters. We won't make use of them for a while, so for now it is good to simply know they exist, and how to spot them. Don't let them scare you off!</p>
 
 
-<h2>Strings</h2> <hr/>
+<h2 id='strings'>Strings</h2> <hr/>
 
 <p>In C strings are represented by the pointer type <code>char*</code>. Under the hood they are stored as a list of characters, where the final character is a special character called the <em>null terminator</em>. Strings are a complicated and important part of C, which we'll learn to use effectively in the next few chapters.</p>
 
-<p>Strings can also be declared literally by putting text between quotation marks. We used this in the previous chapter with our string <code>"Hello, World!"</code>. For now, remember that if you see <code>char*</code>, you can read it as a <em>string</em>.</p> 
+<p>Strings can also be declared literally by putting text between quotation marks. We used this in the previous chapter with our string <code>"Hello, World!"</code>. For now, remember that if you see <code>char*</code>, you can read it as a <em>string</em>.</p>
 
 
-<h2>Conditionals</h2> <hr/>
+<h2 id='conditionals'>Conditionals</h2> <hr/>
 
 <p>Conditional statements let the program perform some code only if certain conditions are met.</p>
 
@@ -120,7 +120,7 @@ float length = sqrt(p.x * p.x + p.y * p.y);
 
 <p>Inside a conditional statement's parentheses any value that is not <code>0</code> will evaluate to true. This is important to remember as many conditions use this to check things implicitly.</p>
 
-<p>If we wished to check if an <code>int</code> called <code>x</code> was greater than <code>10</code> and less then <code>100</code>, we would write the following.</p> 
+<p>If we wished to check if an <code>int</code> called <code>x</code> was greater than <code>10</code> and less then <code>100</code>, we would write the following.</p>
 
 <pre><code data-language='c'>if (x > 10 && x < 100) {
   puts("x is greater than 10 and less than 100!");
@@ -129,7 +129,7 @@ float length = sqrt(p.x * p.x + p.y * p.y);
 }</code></pre>
 
 
-<h2>Loops</h2> <hr/>
+<h2 id='loops'>Loops</h2> <hr/>
 
 <p>Loops allow for some code to be repeated until some condition becomes false, or some counter elapses.</p>
 
@@ -169,7 +169,7 @@ while (i > 0) {
   </ul>
 </div>
 
-<h2>Navigation</h2> 
+<h2>Navigation</h2>
 
 
 <table class="table" style='table-layout: fixed;'>

--- a/chapter4_interactive_prompt.html
+++ b/chapter4_interactive_prompt.html
@@ -1,7 +1,7 @@
 <h1>An Interactive Prompt <small>&bull; Chapter 4</small></h1>
 
 
-<h2>Read, Evaluate, Print</h2> <hr/>
+<h2 id='read_evaluate_print'>Read, Evaluate, Print</h2> <hr/>
 
 <div class='pull-right alert alert-warning' style="margin: 15px; text-align: center;">
   <img src="/static/img/reptile.png" alt="reptile" class="img-responsive" width="187px" height="273px"/>
@@ -15,7 +15,7 @@
 <p>Before building a full <em>REPL</em> we'll start with something simpler. We are going to make a system that prompts the user, and echoes any input straight back. If we make this we can later extend it to parse the user input and evaluate it, as if it were an actual Lisp program.</p>
 
 
-<h2>An Interactive Prompt</h2> <hr/>
+<h2 id='an_interactive_prompt'>An Interactive Prompt</h2> <hr/>
 
 <p>For the basic setup we want to write a loop which repeatedly writes out a message, and then waits for some input. To get user input we can use a function called <code>fgets</code>, which reads any input up until a new line. We need somewhere to store this user input. For this we can declare a constantly sized input buffer.</p>
 
@@ -68,14 +68,14 @@ int main(int argc, char** argv) {
 
 <div class="alert alert-warning">
   <p><strong>How am I meant to know about functions like <code>fgets</code> and <code>printf</code>?</strong></p>
-  
+
   <p>It isn't immediately obvious how to know about these standard functions, and when to use them. When faced with a problem it takes experience to know when it has been solved for you by library functions.</p>
 
   <p>Luckily C has a very small standard library and almost all of it can be learnt in practice. If you want to do something that seems quite basic, or fundamental, it is worth looking at the <a href="http://en.cppreference.com/w/c">reference documentation</a> for the standard library and checking if there are any functions included that do what you want.</p>
 </div>
 
 
-<h2>Compilation</h2> <hr/>
+<h2 id='compilation'>Compilation</h2> <hr/>
 
 <p>You can compile this with the same command as was used in the second chapter.</p>
 
@@ -95,14 +95,14 @@ No You're a Stop being so rude!
 lispy&gt;</code></pre>
 
 
-<h2>Editing input</h2> <hr/>
+<h2 id='editing_input'>Editing input</h2> <hr/>
 
 <p>If you're working on Linux or Mac you'll notice some weird behaviour when you use the arrow keys to attempt to edit your input.</p>
 
 <pre><code data-language='lispy'>Lispy Version 0.0.0.0.3
 Press Ctrl+c to Exit
-  
-lispy> hel^[[D^[[C           
+
+lispy> hel^[[D^[[C
 </code></pre>
 
 <p>Using the arrow keys is creating these weird characters <code>^[[D</code> or <code>^[[C</code>, rather than moving the cursor around in the input. What we really want is to be able to move around on the line, deleting and editing the input in case we make a mistake.</p>
@@ -124,28 +124,28 @@ lispy> hel^[[D^[[C
 #include &lt;editline/history.h&gt;
 
 int main(int argc, char** argv) {
-   
+
   /* Print Version and Exit Information */
   puts("Lispy Version 0.0.0.0.1");
   puts("Press Ctrl+c to Exit\n");
-   
+
   /* In a never ending loop */
   while (1) {
-    
+
     /* Output our prompt and get input */
     char* input = readline("lispy&gt; ");
-    
+
     /* Add input to history */
     add_history(input);
-    
-    /* Echo input back to user */    
+
+    /* Echo input back to user */
     printf("No you're a %s\n", input);
 
     /* Free retrieved input */
     free(input);
-    
+
   }
-  
+
   return 0;
 }</code></pre>
 
@@ -184,7 +184,7 @@ undefined reference to `add_history'
 </div>
 
 
-<h2>The C Preprocessor</h2> <hr/>
+<h2 id='the_c_preprocessor'>The C Preprocessor</h2> <hr/>
 
 <p>For such a small project it might be okay that we have to program differently depending on what operating system we are using, but if I want to send my source code to a friend on different operating system to give me a hand with the programming, it is going to cause problems. In an ideal world I'd wish for my source code to be able to compile no matter where, or on what computer, it is being compiled. This is a general problem in C, and it is called <em>portability</em>. There is not always an easy or correct solution.</p>
 
@@ -232,21 +232,21 @@ void add_history(char* unused) {}
 #endif
 
 int main(int argc, char** argv) {
-   
+
   puts("Lispy Version 0.0.0.0.1");
   puts("Press Ctrl+c to Exit\n");
-   
+
   while (1) {
-    
+
     /* Now in either case readline will be correctly defined */
     char* input = readline("lispy&gt; ");
     add_history(input);
 
     printf("No you're a %s\n", input);
     free(input);
-    
+
   }
-  
+
   return 0;
 }</code></pre>
 
@@ -281,4 +281,3 @@ int main(int argc, char** argv) {
     <td class="text-right"><a href="chapter5_languages"><h4>Languages &rsaquo;</h4></a></td>
   </tr>
 </table>
-

--- a/chapter5_languages.html
+++ b/chapter5_languages.html
@@ -1,7 +1,7 @@
 <h1>Languages <small>&bull; Chapter 5</small></h1>
 
 
-<h2>What is a Programming Language?</h2> <hr/>
+<h2 id='what_is_a_programming_language'>What is a Programming Language?</h2> <hr/>
 
 <p>A programming language is very similar to a real language. There is a structure behind it, and some rules which dictate what is, and isn't, a valid thing to say. When we read and write natural language, we are unconsciously learning these rules, and the same is true for programming languages. We can utilise these rules to understand others, and generate our own speech, or code.</p>
 
@@ -43,14 +43,14 @@
 <p>This is where a library called <code>mpc</code> comes in.</p>
 
 
-<h2>Parser Combinators</h2> <hr/>
+<h2 id='parser_combinators'>Parser Combinators</h2> <hr/>
 
 <p><code>mpc</code> is a <em>Parser Combinator</em> library I have written. This means it is a library that allows you to build programs that understand and process particular languages. These are known as <em>parsers</em>. There are many different ways of building parsers, but the cool thing about using a <em>Parser Combinator</em> library is that it lets you build <em>parsers</em> easily, just by specifying the <em>grammar</em> ... sort of.</p>
 
 <p>Many Parser Combinator libraries actually work by letting you write normal code that <em>looks a bit like</em> a grammar, not by actually specifying a grammar directly. In many situations this is fine, but sometimes it can get clunky and complicated. Luckily for us <code>mpc</code> allows us to write normal code that just looks like a grammar, <em>or</em> we can use special notation to write a grammar directly!</p>
 
 
-<h2>Coding Grammars</h2> <hr/>
+<h2 id='coding_grammars'>Coding Grammars</h2> <hr/>
 
 <p>So what does code that looks like a grammar...<em>look like</em>? Let us take a look at <code>mpc</code> by trying to write code for a grammar that recognizes <a href="http://knowyourmeme.com/memes/doge">the language of Shiba Inu</a>. More colloquially known as <em>Doge</em>. This language we are going to define as follows.</p>
 
@@ -64,7 +64,7 @@
 <p>If you squint you could attempt to read the code as if it were the rules we specified above.</p>
 
 <pre><code data-language='c'>/* Build a parser 'Adjective' to recognize descriptions */
-mpc_parser_t* Adjective = mpc_or(4, 
+mpc_parser_t* Adjective = mpc_or(4,
   mpc_sym("wow"), mpc_sym("many"),
   mpc_sym("so"),  mpc_sym("such")
 );
@@ -72,20 +72,20 @@ mpc_parser_t* Adjective = mpc_or(4,
 /* Build a parser 'Noun' to recognize things */
 mpc_parser_t* Noun = mpc_or(5,
   mpc_sym("lisp"), mpc_sym("language"),
-  mpc_sym("book"),mpc_sym("build"), 
+  mpc_sym("book"),mpc_sym("build"),
   mpc_sym("c")
 );
 </code></pre>
 
 <div class="alert alert-warning">
   <p><strong>How can I access these <code>mpc</code> functions?</strong></p>
-  
+
   <p>For now don't worry about compiling or running any of the sample code in this chapter. Just focus on understanding the theory behind grammars. In the next chapter we'll get set up with <code>mpc</code> and use it for a language closer to our Lisp.</p>
 </div>
 
 <p>To define <code>Phrase</code> we can reference our existing parsers. We need to use the function <code>mpc_and</code>, that specifies one thing is required then another. As input we pass it <code>Adjective</code> and <code>Noun</code>, our previously defined parsers. This function also takes the arguments <code>mpcf_strfold</code> and <code>free</code>, which say how to join or delete the results of these parsers. Ignore these arguments for now.</p>
 
-<pre><code data-language='c'>mpc_parser_t* Phrase = mpc_and(2, mpcf_strfold, 
+<pre><code data-language='c'>mpc_parser_t* Phrase = mpc_and(2, mpcf_strfold,
   Adjective, Noun, free);</code></pre>
 
 <p>To define <em>Doge</em> we must specify that <em>zero or more</em> of some parser is required. For this we need to use the function <code>mpc_many</code>. As before, this function requires the special variable <code>mpcf_strfold</code> to say how the results are joined together, which we can ignore.</p>
@@ -105,7 +105,7 @@ mpc_parser_t* Noun = mpc_or(5,
 <p>If we use more <code>mpc</code> functions, we can slowly build up parsers that parse more and more complicated languages. The code we use <em>sort of</em> reads like a grammar, but becomes much more messy with added complexity. Due to this, taking this approach isn't always an easy task. A whole set of helper functions that build on simple constructs to make frequent tasks easy are all documented on the <a href="http://github.com/orangeduck/mpc">mpc repository</a>. This is a good approach for complicated languages, as it allows for fine-grained control, but won't be required for our needs.</p>
 
 
-<h2>Natural Grammars</h2> <hr/>
+<h2 id='natural_grammars'>Natural Grammars</h2> <hr/>
 
 <p><code>mpc</code> lets us write grammars in a more natural form too. Rather than using C functions that look less like a grammar, we can specify the whole thing in one long string. When using this method we don't have to worry about how to join or discard inputs, with functions such as <code>mpcf_strfold</code>, or <code>free</code>. All of that is done automatically for us.</p>
 

--- a/chapter6_parsing.html
+++ b/chapter6_parsing.html
@@ -7,7 +7,7 @@
 </div>
 
 
-<h2>Polish Notation</h2> <hr/>
+<h2 id='polish_notation'>Polish Notation</h2> <hr/>
 
 <p>To try out <code>mpc</code> we're going to implement a simple grammar that resembles a mathematical subset of our Lisp. It's called <a href="http://en.wikipedia.org/wiki/Polish_notation">Polish Notation</a> and is a notation for arithmetic where the operator comes before the operands.</p>
 
@@ -34,7 +34,7 @@
 </table>
 
 
-<h2>Regular Expressions</h2> <hr/>
+<h2 id='regular_expressions'>Regular Expressions</h2> <hr/>
 
 <p>We should be able to encode most of the above rules using things we know already, but <em>Number</em> and <em>Program</em> might pose some trouble. They contain a couple of constructs we've not learnt how to express yet. We don't know how to express the start or the end of input, optional characters, or range of characters.</p>
 
@@ -57,7 +57,7 @@
 <p>In an <code>mpc</code> grammar we write regular expressions by putting them between forward slashes <code>/</code>. Using the above guide our <em>Number</em> rule can be expressed as a regular expression using the string <code>/-?[0-9]+/</code>.</p>
 
 
-<h2>Installing mpc</h2> <hr/>
+<h2 id='installing_mpc'>Installing mpc</h2> <hr/>
 
 <p>Before we work on writing this grammar we first need to <em>include</em> the <code>mpc</code> headers, and then <em>link</em> to the <code>mpc</code> library, just as we did for <code>editline</code> on Linux and Mac. Starting with your code from chapter 4, you can rename the file to <code>parsing.c</code> and download <code>mpc.h</code> and <code>mpc.c</code> from the <a href="http://github.com/orangeduck/mpc">mpc repo</a>. Put these in the same directory as your source file.</p>
 
@@ -75,12 +75,12 @@
   <p><strong>Hold on, don't you mean <code>#include &lt;mpc.h&gt;</code>?</strong></p>
 
   <p>There are actually two ways to include files in C. One is using angular brackets <code>&lt;&gt;</code> as we've seen so far, and the other is with quotation marks <code>""</code>.</p>
-  
+
   <p>The only difference between the two is that using angular brackets searches the system locations for headers first, while quotation marks searches the current directory first. Because of this system headers such as <code>&lt;stdio.h&gt;</code> are typically put in angular brackets, while local headers such as <code>"mpc.h"</code> are typically put in quotation marks.</p>
 </div>
 
 
-<h2>Polish Notation Grammar</h2> <hr/>
+<h2 id='polish_notation_grammar'>Polish Notation Grammar</h2> <hr/>
 
 <p>Formalising the above rules further, and using some regular expressions, we can write a final grammar for the language of polish notation as follows. Read the below code and verify that it matches what we had written textually, and our ideas of polish notation.</p>
 
@@ -112,7 +112,7 @@ mpc_cleanup(4, Number, Operator, Expr, Lispy);</code></pre>
   <p>That should be <code>mpca_lang</code>, with an <code>a</code> at the end!</p>
 </div>
 
-<h2>Parsing User Input</h2> <hr/>
+<h2 id='parsing_user_input'>Parsing User Input</h2> <hr/>
 
 <p>Our new code creates a <code>mpc</code> parser for our <em>Polish Notation</em> language, but we still need to actually <em>use</em> it on the user input supplied each time from the prompt. We need to edit our <code>while</code> loop so that rather than just echoing user input back, it actually attempts to parse the input using our parser. We can do this by replacing the call to <code>printf</code> with the following <code>mpc</code> code, that makes use of our program parser <code>Lispy</code>.</p>
 

--- a/chapter7_evaluation.html
+++ b/chapter7_evaluation.html
@@ -1,7 +1,7 @@
 <h1>Evaluation <small>&bull; Chapter 7</small></h1>
 
 
-<h2>Trees</h2> <hr/>
+<h2 id='trees'>Trees</h2> <hr/>
 
 <p>Now we can read input, and we have it structured internally, but we are still unable to evaluate it. In this chapter we add the code that evaluates this structure and actually performs the computations encoded within.</p>
 
@@ -55,7 +55,7 @@ printf("First Child Number of children: %i\n",
 </code></pre>
 
 
-<h2>Recursion</h2> <hr/>
+<h2 id='recursion'>Recursion</h2> <hr/>
 
 <p>There is a odd thing about this tree structure. It refers to itself. Each of its children are themselves trees again, and the children of those children are trees yet again. Just like our languages and re-write rules, data in this structure contains repeated substructures that resemble their parents.</p>
 
@@ -99,7 +99,7 @@ printf("First Child Number of children: %i\n",
 <p>Recursive functions can take some thought, so pause now and ensure you understand them before continuing onto other chapters because we'll be making good use of them in the rest of the book. If you are still uncertain, you can attempt some of the bonus marks for this chapter.</p>
 
 
-<h2>Evaluation</h2> <hr/>
+<h2 id='evaluation'>Evaluation</h2> <hr/>
 
 <p>To evaluate the parse tree we are going to write a recursive function. But before we get started, let us try and see what observations we can make about the structure of the tree we get as input. Try printing out some expressions using your program from the previous chapter. What do you notice?</p>
 
@@ -134,26 +134,26 @@ printf("First Child Number of children: %i\n",
 <p>We can use <code>strcmp</code> to check which operator to use, and <code>strstr</code> to check if a tag contains some substring. Altogether our recursive evaluation function looks like this.</p>
 
 <pre><code data-language='c'>long eval(mpc_ast_t* t) {
-  
-  /* If tagged as number return it directly. */ 
+
+  /* If tagged as number return it directly. */
   if (strstr(t-&gt;tag, "number")) {
     return atoi(t-&gt;contents);
   }
-  
+
   /* The operator is always second child. */
   char* op = t-&gt;children[1]-&gt;contents;
-  
+
   /* We store the third child in `x` */
   long x = eval(t-&gt;children[2]);
-  
+
   /* Iterate the remaining children and combining. */
   int i = 3;
   while (strstr(t-&gt;children[i]-&gt;tag, "expr")) {
     x = eval_op(x, op, eval(t-&gt;children[i]));
     i++;
   }
-  
-  return x;  
+
+  return x;
 }</code></pre>
 
 <p>We can define the <code>eval_op</code> function as follows. It takes in a number, an operator string, and another number. It tests for which operator is passed in, and performs the corresponding C operation on the inputs.</p>
@@ -168,7 +168,7 @@ long eval_op(long x, char* op, long y) {
 }</code></pre>
 
 
-<h2>Printing</h2> <hr/>
+<h2 id='printing'>Printing</h2> <hr/>
 
 <p>Instead of printing the tree, we now want to print the result of the evaluation. Therefore we need to pass the tree into our <code>eval</code> function, and print the result we get using <code>printf</code> and the specifier <code>%li</code>, which is used for <code>long</code> type.</p>
 

--- a/chapter8_error_handling.html
+++ b/chapter8_error_handling.html
@@ -1,7 +1,7 @@
 <h1>Error Handling <small>&bull; Chapter 8</small></h1>
 
 
-<h2>Crashes</h2> <hr/>
+<h2 id='crashes'>Crashes</h2> <hr/>
 
 <p>Some of you may have noticed a problem with the previous chapter's program. Try entering this into the prompt and see what happens.</p>
 
@@ -23,7 +23,7 @@ lispy&gt; / 10 0</code></pre>
 
 <p>But there is no magic in how C programs work. If you face a really troublesome bug don't give up or sit and stare at the screen till your eyes bleed. Take this chance to properly learn how to use <code>gdb</code> and <code>valgrind</code>. These will be more weapons in your tool-kit, and after the initial investment, save you a lot of time and pain.</p>
 
-<h2>Lisp Value</h2> <hr/>
+<h2 id='lisp_value'>Lisp Value</h2> <hr/>
 
 <p>There are several ways to deal with errors in C, but in this context my preferred method is to make errors a possible result of evaluating an expression. Then we can say that, in Lispy, an expression will evaluate to <em>either</em> a <em>number</em>, or an <em>error</em>. For example <code>+ 1 2</code> will evaluate to a number, but <code>/ 10 0</code> will evaluate to an error.</p>
 
@@ -39,7 +39,7 @@ typedef struct {
 } lval;</code></pre>
 
 
-<h2>Enumerations</h2> <hr/>
+<h2 id='enumerations'>Enumerations</h2> <hr/>
 
 <p>You'll notice the type of the fields <code>type</code>, and <code>err</code>, is <code>int</code>. This means they are represented by a single integer number.</p>
 
@@ -60,7 +60,7 @@ enum { LVAL_NUM, LVAL_ERR };</code></pre>
 enum { LERR_DIV_ZERO, LERR_BAD_OP, LERR_BAD_NUM };</code></pre>
 
 
-<h2>Lisp Value Functions</h2> <hr/>
+<h2 id='lisp_value_functions'>Lisp Value Functions</h2> <hr/>
 
 <p>Our <code>lval</code> type is almost ready to go. Unlike the previous <code>long</code> type we have no current method for creating new instances of it. To do this we can declare two functions that construct an <code>lval</code> of either an <em>error</em> type or a <em>number</em> type.</p>
 
@@ -113,7 +113,7 @@ void lval_print(lval v) {
 void lval_println(lval v) { lval_print(v); putchar('\n'); }</code></pre>
 
 
-<h2>Evaluating Errors</h2> <hr/>
+<h2 id='evaluating_errors'>Evaluating Errors</h2> <hr/>
 
 <p>Now that we know how to work with the <code>lval</code> type, we need to change our evaluation functions to use it instead of <code>long</code>.</p>
 
@@ -133,8 +133,8 @@ void lval_println(lval v) { lval_print(v); putchar('\n'); }</code></pre>
   if (strcmp(op, "*") == 0) { return lval_num(x.num * y.num); }
   if (strcmp(op, "/") == 0) {
     /* If second operand is zero return error */
-    return y.num == 0 
-      ? lval_err(LERR_DIV_ZERO) 
+    return y.num == 0
+      ? lval_err(LERR_DIV_ZERO)
       : lval_num(x.num / y.num);
   }
 
@@ -156,24 +156,24 @@ void lval_println(lval v) { lval_print(v); putchar('\n'); }</code></pre>
 <p>In this case we use the <code>strtol</code> function to convert from string to <code>long</code>. This allows us to check a special variable <code>errno</code> to ensure the conversion goes correctly. This is a more robust way to convert numbers than our previous method using <code>atoi</code>.</p>
 
 <pre><code data-language='c'>lval eval(mpc_ast_t* t) {
-  
+
   if (strstr(t-&gt;tag, "number")) {
     /* Check if there is some error in conversion */
     errno = 0;
     long x = strtol(t-&gt;contents, NULL, 10);
     return errno != ERANGE ? lval_num(x) : lval_err(LERR_BAD_NUM);
   }
-  
-  char* op = t-&gt;children[1]-&gt;contents;  
+
+  char* op = t-&gt;children[1]-&gt;contents;
   lval x = eval(t-&gt;children[2]);
-  
+
   int i = 3;
   while (strstr(t-&gt;children[i]-&gt;tag, "expr")) {
     x = eval_op(x, op, eval(t-&gt;children[i]));
     i++;
   }
-  
-  return x;  
+
+  return x;
 }</code></pre>
 
 <p>The final small step is to change how we print the result found by our evaluation to use our newly defined printing function which can print any type of <code>lval</code>.</p>
@@ -190,7 +190,7 @@ lispy&gt; / 10 2
 5</code></pre>
 
 
-<h2>Plumbing</h2> <hr/>
+<h2 id='plumbing'>Plumbing</h2> <hr/>
 
 <div class='pull-right alert alert-warning' style="margin: 15px; text-align: center;">
   <img src="/static/img/plumbing.png" alt="plumbing" class="img-responsive" width="368px" height="302px"/>

--- a/chapter9_s_expressions.html
+++ b/chapter9_s_expressions.html
@@ -1,7 +1,7 @@
 <h1>S-Expressions <small>&bull; Chapter 9</small></h1>
 
 
-<h2>Lists and Lisps</h2> <hr/>
+<h2 id='lists_and_lisps'>Lists and Lisps</h2> <hr/>
 
 <div class='pull-right alert alert-warning' style="margin: 15px; text-align: center;">
   <img src="/static/img/lisp.png" alt="lisp" class="img-responsive" width="253px" height="300px"/>
@@ -17,7 +17,7 @@
 <p>By introducing S-Expressions we'll finally be entering the world of Lisp.</p>
 
 
-<h2>Pointers</h2> <hr/>
+<h2 id='pointers'>Pointers</h2> <hr/>
 
 <p>In C no concept of lists can be explored without dealing properly with pointers. Pointers are a famously misunderstood aspect of C. They are difficult to teach because while being conceptually very simple, they come with a lot of new terminology, and often no clear use-case. This makes them appear far more monstrous than they are. Luckily for us, we have a couple ideal use-cases, both of which are extremely typical in C, and will likely end up being how you use pointers 90% of the time.</p>
 
@@ -44,7 +44,7 @@
 <p>Finally to get the data at an address, called <em>dereferencing</em>, we use the <code>*</code> operator on the left-hand side of a variable. To get the data at the field of a pointer to a struct we use the arrow <code>-&gt;</code>. This you saw in chapter 7.</p>
 
 
-<h2>The Stack &amp; The Heap</h2> <hr/>
+<h2 id='the_stack_and_the_heap'>The Stack &amp; The Heap</h2> <hr/>
 
 <p>I said that memory can be visualised of as one long list of bytes. Actually it is better to imagine it split into two sections. These sections are called <em>The Stack</em> and <em>The Heap</em>.</p>
 
@@ -78,7 +78,7 @@
 <p>I Imagine the Heap like a huge U-Store-It. We can call up the reception with <code>malloc</code> and request a number of boxes. With these boxes we can do what we want, and we know they will persist no matter how messy the building site gets. We can take things to and from the U-Store-It and the building site. It is useful to store materials and large objects which we only need to retrieve once in a while. The only problem is we need to remember to call the receptionist again with <code>free</code> when we are done. Otherwise soon we'll have requested all the boxes, have no space, and run up a huge bill.</p>
 
 
-<h2>Parsing Expressions</h2> <hr/>
+<h2 id='parsing_expressions'>Parsing Expressions</h2> <hr/>
 
 <p>Because we're now thinking in S-Expressions, and not Polish Notation we need to update our parser. The syntax for S-Expressions is simple. It is just a number of other Expressions between parentheses, where an Expression can be a Number, Operator, or other S-Expression . We can modify our existing parse rules to reflect this. We also are going to rename our <code>operator</code> rule to <code>symbol</code>. This is in anticipation of adding more operators, variables and functions later.</p>
 
@@ -103,13 +103,13 @@ mpca_lang(MPCA_LANG_DEFAULT,
 <pre><code data-language='c'>mpc_cleanup(5, Number, Symbol, Sexpr, Expr, Lispy);</code></pre>
 
 
-<h2>Expression Structure</h2> <hr/>
+<h2 id='expression_structure'>Expression Structure</h2> <hr/>
 
 <p>We need a way to store S-Expressions as <code>lval</code>. This means we'll also need to store <em>Symbols</em> and <em>Numbers</em>. We're going to add two new <code>lval</code> types to the <code>enum</code>. The first is <code>LVAL_SYM</code>, which we're going to use to represent operators such as <code>+</code>. The second new type is <code>LVAL_SEXPR</code> which we're going to use to represent S-Expressions.</p>
 
 <pre><code data-language='c'>enum { LVAL_ERR, LVAL_NUM, LVAL_SYM, LVAL_SEXPR };</code></pre>
 
-<p>S-Expressions are variable length <em>lists</em> of other values. As we learnt at the beginning of this chapter we can't create variable length structs, so we are going to need to use a pointer. We are going to create a pointer field <code>cell</code> which points to a location where we store a list of <code>lval*</code>. More specifically pointers to the other individual <code>lval</code>. Our field should therefore be a double pointer type <code>lval**</code>. A <em>pointer to <code>lval</code> pointers</em>. We will also need to keep track of how many <code>lval*</code> are in this list, so we add an extra field <code>count</code> to record this.</p> 
+<p>S-Expressions are variable length <em>lists</em> of other values. As we learnt at the beginning of this chapter we can't create variable length structs, so we are going to need to use a pointer. We are going to create a pointer field <code>cell</code> which points to a location where we store a list of <code>lval*</code>. More specifically pointers to the other individual <code>lval</code>. Our field should therefore be a double pointer type <code>lval**</code>. A <em>pointer to <code>lval</code> pointers</em>. We will also need to keep track of how many <code>lval*</code> are in this list, so we add an extra field <code>count</code> to record this.</p>
 
 <p>To represent symbols we're going to use a string. We're also going to change the representation of errors to a string. This means we can store a unique error message rather than just an error code. This will make our error reporting better and more flexible, and we can get rid of the original error <code>enum</code>. Our updated <code>lval</code> struct looks like this.</p>
 
@@ -130,7 +130,7 @@ mpca_lang(MPCA_LANG_DEFAULT,
   <p>There is an old programming joke which says you can rate C programmers by how many stars are on their pointers.</p>
 
   <p>Beginner's programs might only use <code>char*</code> or the odd <code>int*</code>, so they were called <em>one star programmers</em>. Most intermediate programs contain double pointer types such as <code>lval**</code>. These programmers are therefore called <em>two star programmers</em>. To spot a triple pointer is something special. You would be viewing the work of someone grand and terrible, writing code not meant to be read with mortal eyes. As such being called a <em>three star programmer</em> is rarely a compliment.</p>
-  
+
   <p>As far as I know, a quadruple pointer has never been seen in the wild.</p>
 </div>
 
@@ -140,13 +140,13 @@ mpca_lang(MPCA_LANG_DEFAULT,
   <p>Our new definition of <code>lval</code> needs to contain a reference to itself. This means we have to slightly change how it is defined. Before we open the curly brackets we can put the name of the struct, and then refer to this inside the definition using <code>struct lval</code>. Even though a struct can refer to its own type, it must only contain pointers to its own type, not its own type directly. Otherwise the size of the struct would refer to itself, and grow infinite in size when you tried to calculate it!</p>
 </div>
 
-<h2>Constructors &amp; Destructors</h2> <hr/>
+<h2 id="constructors_and_destructors">Constructors &amp; Destructors</h2> <hr/>
 
 <p>We can change our <code>lval</code> construction functions to return pointers to an <code>lval</code>, rather than one directly. This will make keeping track of <code>lval</code> variables easier. For this we need to use <code>malloc</code> with the <code>sizeof</code> function to allocate enough space for the <code>lval</code> struct, and then to fill in the fields with the relevant information using the arrow operator <code>-&gt;</code>.</p>
 
 <p>When we construct an <code>lval</code> its fields may contain pointers to other things that have been allocated on the heap. This means we need to be careful. Whenever we are finished with an <code>lval</code> we also need to delete the things it points to on the heap. We will have to make a rule for ourselves. Whenever we free the memory allocated for an <code>lval</code>, we also free all the things it points to.</p>
 
-<pre><code data-language='c'>/* Construct a pointer to a new Number lval */ 
+<pre><code data-language='c'>/* Construct a pointer to a new Number lval */
 lval* lval_num(long x) {
   lval* v = malloc(sizeof(lval));
   v-&gt;type = LVAL_NUM;
@@ -155,7 +155,7 @@ lval* lval_num(long x) {
 }
 </code></pre>
 
-<pre><code data-language='c'>/* Construct a pointer to a new Error lval */ 
+<pre><code data-language='c'>/* Construct a pointer to a new Error lval */
 lval* lval_err(char* m) {
   lval* v = malloc(sizeof(lval));
   v-&gt;type = LVAL_ERR;
@@ -165,7 +165,7 @@ lval* lval_err(char* m) {
 }
 </code></pre>
 
-<pre><code data-language='c'>/* Construct a pointer to a new Symbol lval */ 
+<pre><code data-language='c'>/* Construct a pointer to a new Symbol lval */
 lval* lval_sym(char* s) {
   lval* v = malloc(sizeof(lval));
   v-&gt;type = LVAL_SYM;
@@ -195,7 +195,7 @@ lval* lval_sexpr(void) {
   <p><strong>Why are you using <code>strlen(s) + 1</code>?</strong></p>
 
   <p>In C strings are <em>null terminated</em>. This means that the final character of them is always the zero character <code>\0</code>. This is a convention in C to signal the end of a string. It is important that all strings are stored this way otherwise programs will break in nasty ways.</p>
-  
+
   <p>The <code>strlen</code> function only returns the number of bytes in a string <em>excluding</em> the null terminator. This is why we need to add one, to ensure there is enough allocated space for it all!</p>
 </div>
 
@@ -224,9 +224,9 @@ lval* lval_sexpr(void) {
   /* Free the memory allocated for the "lval" struct itself */
   free(v);
 }</code></pre>
-    
-    
-<h2>Reading Expressions</h2> <hr/>
+
+
+<h2 id='reading_expressions'>Reading Expressions</h2> <hr/>
 
 <p>First we are going to <em>read</em> in the program and construct an <code>lval*</code> that represents it all. Then we are going to <em>evaluate</em> this <code>lval*</code> to get the result of our program. This first stage should convert the <em>abstract syntax tree</em> into an S-Expression, and the second stage should evaluate this S-Expression using our normal Lisp rules.</p>
 
@@ -240,7 +240,7 @@ lval* lval_sexpr(void) {
   <p><strong>Don't Lisps use <a href="http://en.wikipedia.org/wiki/Cons">Cons cells</a>?</strong></p>
 
   <p>Other Lisps have a slightly different definition of what an S-Expression is. In most other Lisps S-Expressions are defined inductively as either an <em>atom</em> such as a symbol of number, or two other S-Expressions joined, or <em>cons</em>, together.</p>
-  
+
   <p>This naturally leads to an implementation using <em>linked lists</em>, a different data structure to the one we are using. I choose to represent S-Expressions as a variable sized array in this book for the purposes of simplicity, but it is important to be aware that the official definition, and typical implementation are both subtly different.</p>
 </div>
 
@@ -260,7 +260,7 @@ lval* lval_sexpr(void) {
 
   /* If root (&gt;) or sexpr then create empty list */
   lval* x = NULL;
-  if (strcmp(t-&gt;tag, "&gt;") == 0) { x = lval_sexpr(); } 
+  if (strcmp(t-&gt;tag, "&gt;") == 0) { x = lval_sexpr(); }
   if (strstr(t-&gt;tag, "sexpr"))  { x = lval_sexpr(); }
 
   /* Fill this list with any valid expression contained within */
@@ -284,7 +284,7 @@ lval* lval_sexpr(void) {
 }
 </code></pre>
 
-<h2>Printing Expressions</h2> <hr/>
+<h2 id='printing_expressions'>Printing Expressions</h2> <hr/>
 
 <p>We are now so close to trying out all of our new changes. We need to modify our print function to print out S-Expressions types. Using this we can double check that the <em>reading</em> phase is working correctly by printing out the S-Expressions we read in and verifying they match those we input.</p>
 
@@ -321,7 +321,7 @@ void lval_println(lval* v) { lval_print(v); putchar('\n'); }</code></pre>
   <p><strong>I can't declare these functions because they call each other.</strong></p>
 
   <p>The <code>lval_expr_print</code> function calls the <code>lval_print</code> function and vice-versa. There is no way we can order them in the source file to resolve this dependency. Instead we need to <em>forward declare</em> one of them. This is declaring a function without giving it a body. It lets other functions call it, while allowing you to define it properly later on. To write a forward declaration, write the function definition but instead of the body put a semicolon <code>;</code>. In this example we should put <code>void lval_print(lval* v);</code> somewhere in the source file before <code>lval_expr_print</code>.</p>
-  
+
   <p>You'll definitely run into this later, and I won't always alert you to it, so try to remember how to fix it!</p>
 </div>
 
@@ -343,7 +343,7 @@ lispy&gt; *     55     101  (+ 0 0 0)
 lispy&gt;</code></pre>
 
 
-<h2>Evaluating Expressions</h2> <hr/>
+<h2 id='evaluating_expressions'>Evaluating Expressions</h2> <hr/>
 
 <p>The behaviour of our evaluation function is largely the same as before. We need to adapt it to deal with <code>lval*</code> and our more relaxed definition of what constitutes an expression. We can think of our evaluation function as a kind of transformer. It takes in some <code>lval*</code> and transforms it in some way to some new <code>lval*</code>. In some cases it can just return exactly the same thing. In other cases it may modify the input <code>lval*</code> and return it. In many cases it will delete the input, and return something completely different. If we are going to return something new we must always remember to delete the <code>lval*</code> we get as input.</p>
 
@@ -432,7 +432,7 @@ lispy&gt;</code></pre>
 <p>If there have been no errors the input arguments are deleted and the new expression returned.</p>
 
 <pre><code data-language="c">lval* builtin_op(lval* a, char* op) {
-  
+
   /* Ensure all arguments are numbers */
   for (int i = 0; i < a->count; i++) {
     if (a-&gt;cell[i]-&gt;type != LVAL_NUM) {
@@ -440,7 +440,7 @@ lispy&gt;</code></pre>
       return lval_err("Cannot operate on non-number!");
     }
   }
-  
+
   /* Pop the first element */
   lval* x = lval_pop(a, 0);
 

--- a/contents.html
+++ b/contents.html
@@ -17,12 +17,12 @@
 <h3><a href="chapter1_introduction">Chapter 1 &bull; Introduction</a></h3>
 <hr/>
 <ul>
-  <li>About</li>
-  <li>Who this is for</li>
-  <li>Why learn C</li>
-  <li>How to learn C</li>
-  <li>Why build a Lisp</li>
-  <li>Your own Lisp</li>
+  <li><a href="chapter1_introduction#about">About</a></li>
+  <li><a href="chapter1_introduction#who_this_is_for">Who this is for</a></li>
+  <li><a href="chapter1_introduction#why_learn_c">Why learn C</a></li>
+  <li><a href="chapter1_introduction#how_to_learn_c">How to learn C</a></li>
+  <li><a href="chapter1_introduction#why_build_a_lisp">Why build a Lisp</a></li>
+  <li><a href="chapter1_introduction#your_own_lisp">Your own Lisp</a></li>
 </ul>
 
 <div style="margin-top:50px"></div>
@@ -30,13 +30,13 @@
 <h3><a href="chapter2_installation">Chapter 2 &bull; Installation</a></h3>
 <hr/>
 <ul>
-  <li>Setup</li>
-  <li>Text Editor</li>
-  <li>Compiler</li>
-  <li>Hello World</li>
-  <li>Compilation</li>
-  <li>Errors</li>
-  <li>Documentation</li>
+  <li><a href="chapter2_installation#setup">Setup</a></li>
+  <li><a href="chapter2_installation#text_editor">Text Editor</a></li>
+  <li><a href="chapter2_installation#compiler">Compiler</a></li>
+  <li><a href="chapter2_installation#hello_world">Hello World</a></li>
+  <li><a href="chapter2_installation#compilation">Compilation</a></li>
+  <li><a href="chapter2_installation#errors">Errors</a></li>
+  <li><a href="chapter2_installation#documentation">Documentation</a></li>
 </ul>
 
 <div style="margin-top:50px"></div>
@@ -44,15 +44,15 @@
 <h3><a href="chapter3_basics">Chapter 3 &bull; Basics</a></h3>
 <hr/>
 <ul>
-  <li>Overview</li>
-  <li>Programs</li>
-  <li>Variables</li>
-  <li>Function Declarations</li>
-  <li>Structure Declarations</li>
-  <li>Pointers</li>
-  <li>Strings</li>
-  <li>Conditionals</li>
-  <li>Loops</li>
+  <li><a href="chapter3_basics#overview">Overview</a></li>
+  <li><a href="chapter3_basics#programs">Programs</a></li>
+  <li><a href="chapter3_basics#variables">Variables</a></li>
+  <li><a href="chapter3_basics#function_declarations">Function Declarations</a></li>
+  <li><a href="chapter3_basics#structure_declarations">Structure Declarations</a></li>
+  <li><a href="chapter3_basics#pointers">Pointers</a></li>
+  <li><a href="chapter3_basics#strings">Strings</a></li>
+  <li><a href="chapter3_basics#conditionals">Conditionals</a></li>
+  <li><a href="chapter3_basics#loops">Loops</a></li>
 </ul>
 
 <div style="margin-top:50px"></div>

--- a/contents.html
+++ b/contents.html
@@ -60,11 +60,11 @@
 <h3><a href="chapter4_interactive_prompt">Chapter 4 &bull; An Interactive Prompt</a></h3>
 <hr/>
 <ul>
-  <li>Read, Evaluate, Print</li>
-  <li>An Interactive Prompt</li>
-  <li>Compilation</li>
-  <li>Editing input</li>
-  <li>The C Preprocessor</li>
+  <li><a href="chapter4_interactive_prompt#read_evaluate_print">Read, Evaluate, Print</a></li>
+  <li><a href="chapter4_interactive_prompt#an_interactive_prompt">An Interactive Prompt</a></li>
+  <li><a href="chapter4_interactive_prompt#compilation">Compilation</a></li>
+  <li><a href="chapter4_interactive_prompt#editing_input">Editing input</a></li>
+  <li><a href="chapter4_interactive_prompt#the_c_preprocessor">The C Preprocessor</a></li>
 </ul>
 
 <div style="margin-top:50px"></div>
@@ -72,10 +72,10 @@
 <h3><a href="chapter5_languages">Chapter 5 &bull; Languages</a></h3>
 <hr/>
 <ul>
-  <li>What is a Programming Language?</li>
-  <li>Parser Combinators</li>
-  <li>Coding Grammars</li>
-  <li>Natural Grammars</li>
+  <li><a href="chapter5_languages#what_is_a_programming_language">What is a Programming Language?</a></li>
+  <li><a href="chapter5_languages#parser_combinators">Parser Combinators</a></li>
+  <li><a href="chapter5_languages#coding_grammars">Coding Grammars</a></li>
+  <li><a href="chapter5_languages#natural_grammars">Natural Grammars</a></li>
 </ul>
 
 <div style="margin-top:50px"></div>
@@ -83,11 +83,11 @@
 <h3><a href="chapter6_parsing">Chapter 6 &bull; Parsing</a></h3>
 <hr/>
 <ul>
-  <li>Polish Notation</li>
-  <li>Regular Expressions</li>
-  <li>Installing mpc</li>
-  <li>Polish Notation Grammar</li>
-  <li>Parsing User Input</li>
+  <li><a href="chapter6_parsing#polish_notation">Polish Notation</a></li>
+  <li><a href="chapter6_parsing#regular_expressions">Regular Expressions</a></li>
+  <li><a href="chapter6_parsing#installing_mpc">Installing mpc</a></li>
+  <li><a href="chapter6_parsing#polish_notation_grammar">Polish Notation Grammar</a></li>
+  <li><a href="chapter6_parsing#parsing_user_input">Parsing User Input</a></li>
 </ul>
 
 <div style="margin-top:50px"></div>
@@ -95,10 +95,10 @@
 <h3><a href="chapter7_evaluation">Chapter 7 &bull; Evaluation</a></h3>
 <hr/>
 <ul>
-  <li>Trees</li>
-  <li>Recursion</li>
-  <li>Evaluation</li>
-  <li>Printing</li>
+  <li><a href="chapter7_evaluation#trees">Trees</a></li>
+  <li><a href="chapter7_evaluation#recursion">Recursion</a></li>
+  <li><a href="chapter7_evaluation#evaluation">Evaluation</a></li>
+  <li><a href="chapter7_evaluation#printing">Printing</a></li>
 </ul>
 
 <div style="margin-top:50px"></div>

--- a/contents.html
+++ b/contents.html
@@ -180,11 +180,11 @@
 <h3><a href="chapter13_conditionals">Chapter 13 &bull; Conditionals</a></h3>
 <hr/>
 <ul>
-  <li>Doing it yourself</li>
-  <li>Ordering</li>
-  <li>Equality</li>
-  <li>If Function</li>
-  <li>Recursive Functions</li>
+  <li><a href="chapter13_conditionals#doing_it_yourself">Doing it yourself</a></li>
+  <li><a href="chapter13_conditionals#ordering">Ordering</a></li>
+  <li><a href="chapter13_conditionals#equality">Equality</a></li>
+  <li><a href="chapter13_conditionals#if_function">If Function</a></li>
+  <li><a href="chapter13_conditionals#recursive_functions">Recursive Functions</a></li>
 </ul>
 
 <div style="margin-top:50px"></div>
@@ -192,15 +192,15 @@
 <h3><a href="chapter14_strings">Chapter 14 &bull; Strings</a></h3>
 <hr/>
 <ul>
-  <li>Libraries</li>
-  <li>String Type</li>
-  <li>Reading Strings</li>
-  <li>Comments</li>
-  <li>Load Function</li>
-  <li>Command Line Arguments</li>
-  <li>Print Function</li>
-  <li>Error Function</li>
-  <li>Finishing Up</li>
+  <li><a href="chapter14_strings#libraries">Libraries</a></li>
+  <li><a href="chapter14_strings#string_type">String Type</a></li>
+  <li><a href="chapter14_strings#reading_strings">Reading Strings</a></li>
+  <li><a href="chapter14_strings#comments">Comments</a></li>
+  <li><a href="chapter14_strings#load_function">Load Function</a></li>
+  <li><a href="chapter14_strings#command_line_arguments">Command Line Arguments</a></li>
+  <li><a href="chapter14_strings#print_function">Print Function</a></li>
+  <li><a href="chapter14_strings#error_function">Error Function</a></li>
+  <li><a href="chapter14_strings#finishing_up">Finishing Up</a></li>
 </ul>
 
 <div style="margin-top:50px"></div>
@@ -208,14 +208,14 @@
 <h3><a href="chapter15_standard_library">Chapter 15 &bull; Standard Library</a></h3>
 <hr/>
 <ul>
-  <li>Minimalism</li>
-  <li>Atom</li>
-  <li>Building Blocks</li>
-  <li>Logical Operators</li>
-  <li>Miscellaneous Functions</li>
-  <li>List Functions</li>
-  <li>Conditional Functions</li>
-  <li>Fibonacci</li>
+  <li><a href="chapter15_standard_library#minimalism">Minimalism</a></li>
+  <li><a href="chapter15_standard_library#atoms">Atoms</a></li>
+  <li><a href="chapter15_standard_library#building_blocks">Building Blocks</a></li>
+  <li><a href="chapter15_standard_library#logical_operators">Logical Operators</a></li>
+  <li><a href="chapter15_standard_library#miscellaneous_functions">Miscellaneous Functions</a></li>
+  <li><a href="chapter15_standard_library#list_functions">List Functions</a></li>
+  <li><a href="chapter15_standard_library#conditional_functions">Conditional Functions</a></li>
+  <li><a href="chapter15_standard_library#fibonacci">Fibonacci</a></li>
 </ul>
 
 <div style="margin-top:50px"></div>
@@ -223,19 +223,19 @@
 <h3><a href="chapter16_bonus_projects">Chapter 16 &bull; Bonus Projects</a></h3>
 <hr/>
 <ul>
-  <li>Only the Beginning</li>
-  <li>Native Types</li>
-  <li>User Defined Types</li>
-  <li>List Literal</li>
-  <li>Operating System Interaction</li>
-  <li>Macros</li>
-  <li>Variable Hashtable</li>
-  <li>Pool Allocation</li>
-  <li>Garbage Collection</li>
-  <li>Tail Call Optimisation</li>
-  <li>Lexical Scoping</li>
-  <li>Static Typing</li>
-  <li>Conclusion</li>
+  <li><a href="chapter16_bonus_projects#only_the_beginning">Only the Beginning</a></li>
+  <li><a href="chapter16_bonus_projects#native_types">Native Types</a></li>
+  <li><a href="chapter16_bonus_projects#user_defined_types">User Defined Types</a></li>
+  <li><a href="chapter16_bonus_projects#list_literal">List Literal</a></li>
+  <li><a href="chapter16_bonus_projects#operating_system_interaction">Operating System Interaction</a></li>
+  <li><a href="chapter16_bonus_projects#macros">Macros</a></li>
+  <li><a href="chapter16_bonus_projects#variable_hashtable">Variable Hashtable</a></li>
+  <li><a href="chapter16_bonus_projects#pool_allocation">Pool Allocation</a></li>
+  <li><a href="chapter16_bonus_projects#garbage_collection">Garbage Collection</a></li>
+  <li><a href="chapter16_bonus_projects#tail_call_optimisation">Tail Call Optimisation</a></li>
+  <li><a href="chapter16_bonus_projects#lexical_scoping">Lexical Scoping</a></li>
+  <li><a href="chapter16_bonus_projects#static_typing">Static Typing</a></li>
+  <li><a href="chapter16_bonus_projects#conclusion">Conclusion</a></li>
 </ul>
 
 <h3><a href="credits">Credits</a></h3> <hr/>

--- a/contents.html
+++ b/contents.html
@@ -106,12 +106,12 @@
 <h3><a href="chapter8_error_handling">Chapter 8 &bull; Error Handling</a></h3>
 <hr/>
 <ul>
-  <li>Crashes</li>
-  <li>Lisp Value</li>
-  <li>Enumerations</li>
-  <li>Lisp Value Functions</li>
-  <li>Evaluating Errors</li>
-  <li>Plumbing</li>
+  <li><a href="chapter8_error_handling#crashes">Crashes</a></li>
+  <li><a href="chapter8_error_handling#lisp_value">Lisp Value</a></li>
+  <li><a href="chapter8_error_handling#enumerations">Enumerations</a></li>
+  <li><a href="chapter8_error_handling#lisp_value_functions">Lisp Value Functions</a></li>
+  <li><a href="chapter8_error_handling#evaluating_errors">Evaluating Errors</a></li>
+  <li><a href="chapter8_error_handling#plumbing">Plumbing</a></li>
 </ul>
 
 <div style="margin-top:50px"></div>
@@ -119,16 +119,15 @@
 <h3><a href="chapter9_s_expressions">Chapter 9 &bull; S-Expressions</a></h3>
 <hr/>
 <ul>
-  <li>Lists and Lisps</li>
-  <li>Types of List</li>
-  <li>Pointers</li>
-  <li>The Stack &amp; The Heap</li>
-  <li>Parsing Expressions</li>
-  <li>Expression Structure</li>
-  <li>Constructors &amp; Destructors</li>
-  <li>Reading Expressions</li>
-  <li>Printing Expressions</li>
-  <li>Evaluating Expressions</li>
+  <li><a href="chapter9_s_expressions#lists_and_lisps">Lists and Lisps</a></li>
+  <li><a href="chapter9_s_expressions#pointers">Pointers</a></li>
+  <li><a href="chapter9_s_expressions#the_stack_and_the_heap">The Stack &amp; The Heap</a></li>
+  <li><a href="chapter9_s_expressions#parsing_expressions">Parsing Expressions</a></li>
+  <li><a href="chapter9_s_expressions#expression_structure">Expression Structure</a></li>
+  <li><a href="chapter9_s_expressions#constructors_and_destructors">Constructors &amp; Destructors</a></li>
+  <li><a href="chapter9_s_expressions#reading_expressions">Reading Expressions</a></li>
+  <li><a href="chapter9_s_expressions#printing_expressions">Printing Expressions</a></li>
+  <li><a href="chapter9_s_expressions#evaluating_expressions">Evaluating Expressions</a></li>
 </ul>
 
 <div style="margin-top:50px"></div>
@@ -136,13 +135,13 @@
 <h3><a href="chapter10_q_expressions">Chapter 10 &bull; Q-Expressions</a></h3>
 <hr/>
 <ul>
-  <li>Adding Features</li>
-  <li>Quoted Expressions</li>
-  <li>Reading Q-Expressions</li>
-  <li>Builtin Functions</li>
-  <li>First Attempt</li>
-  <li>Macros</li>
-  <li>Builtins Lookup</li>
+  <li><a href="chapter10_q_expressions#adding_features">Adding Features</a></li>
+  <li><a href="chapter10_q_expressions#quoted_expressions">Quoted Expressions</a></li>
+  <li><a href="chapter10_q_expressions#reading_q-expressions">Reading Q-Expressions</a></li>
+  <li><a href="chapter10_q_expressions#builtin_functions">Builtin Functions</a></li>
+  <li><a href="chapter10_q_expressions#first_attempt">First Attempt</a></li>
+  <li><a href="chapter10_q_expressions#macros">Macros</a></li>
+  <li><a href="chapter10_q_expressions#builtins_lookup">Builtins Lookup</a></li>
 </ul>
 
 <div style="margin-top:50px"></div>
@@ -150,15 +149,16 @@
 <h3><a href="chapter11_variables">Chapter 11 &bull; Variables</a></h3>
 <hr/>
 <ul>
-  <li>Immutability</li>
-  <li>Function Pointers</li>
-  <li>Cyclic Types</li>
-  <li>Function Type</li>
-  <li>Environment</li>
-  <li>Variable Evaluation</li>
-  <li>Builtins</li>
-  <li>Define Function</li>
-  <li>Error Reporting</li>
+  <li><a href="chapter11_variables#immutability">Immutability</a></li>
+  <li><a href="chapter11_variables#symbol_syntax">Symbol Syntax</a></li>
+  <li><a href="chapter11_variables#function_pointers">Function Pointers</a></li>
+  <li><a href="chapter11_variables#cyclic_types">Cyclic Types</a></li>
+  <li><a href="chapter11_variables#function_type">Function Type</a></li>
+  <li><a href="chapter11_variables#environment">Environment</a></li>
+  <li><a href="chapter11_variables#variable_evaluation">Variable Evaluation</a></li>
+  <li><a href="chapter11_variables#builtins">Builtins</a></li>
+  <li><a href="chapter11_variables#define_function">Define Function</a></li>
+  <li><a href="chapter11_variables#error_reporting">Error Reporting</a></li>
 </ul>
 
 <div style="margin-top:50px"></div>
@@ -166,13 +166,13 @@
 <h3><a href="chapter12_functions">Chapter 12 &bull; Functions</a></h3>
 <hr/>
 <ul>
-  <li>What is a Function?</li>
-  <li>Function Type</li>
-  <li>Lambda Function</li>
-  <li>Parent Environment</li>
-  <li>Function Calling</li>
-  <li>Variable Arguments</li>
-  <li>Interesting Functions</li>
+  <li><a href="chapter12_functions#what_is_a_function">What is a Function?</a></li>
+  <li><a href="chapter12_functions#function_type">Function Type</a></li>
+  <li><a href="chapter12_functions#lambda_function">Lambda Function</a></li>
+  <li><a href="chapter12_functions#parent_environment">Parent Environment</a></li>
+  <li><a href="chapter12_functions#function_calling">Function Calling</a></li>
+  <li><a href="chapter12_functions#variable_arguments">Variable Arguments</a></li>
+  <li><a href="chapter12_functions#interesting_functions">Interesting Functions</a></li>
 </ul>
 
 <div style="margin-top:50px"></div>


### PR DESCRIPTION
While reading the book, I found that it was difficult to navigate directly to a section of a chapter. One could only choose the chapter and then scroll down, which is probably too slow for most. This pull request fixes this issue by providing links to sections in the table of contents.

Summary of changes:
- All sections are assigned an 'id' attribute to which one can link;
- Table of contents now links to these sections;
- Removes 'Types of List' from table of contents (no such section actually exists in Chapter 9);
- Adds 'Symbol Syntax' to table of contents (it is an existing section in Chapter 11 for which there was no bullet);
- Renames 'Atom' to 'Atoms' in table of contents (the matching section in Chapter 15 is named 'Atoms').