### PR TITLE
Removed extra curly brackets

### DIFF
--- a/chapter9_s_expressions.html
+++ b/chapter9_s_expressions.html
@@ -267,8 +267,6 @@ lval* lval_sexpr(void) {
   for (int i = 0; i &lt; t-&gt;children_num; i++) {
     if (strcmp(t-&gt;children[i]-&gt;contents, "(") == 0) { continue; }
     if (strcmp(t-&gt;children[i]-&gt;contents, ")") == 0) { continue; }
-    if (strcmp(t-&gt;children[i]-&gt;contents, "}") == 0) { continue; }
-    if (strcmp(t-&gt;children[i]-&gt;contents, "{") == 0) { continue; }
     if (strcmp(t-&gt;children[i]-&gt;tag,  "regex") == 0) { continue; }
     x = lval_add(x, lval_read(t-&gt;children[i]));
   }

--- a/src/s_expressions.c
+++ b/src/s_expressions.c
@@ -258,8 +258,6 @@ lval* lval_read(mpc_ast_t* t) {
   for (int i = 0; i < t->children_num; i++) {
     if (strcmp(t->children[i]->contents, "(") == 0) { continue; }
     if (strcmp(t->children[i]->contents, ")") == 0) { continue; }
-    if (strcmp(t->children[i]->contents, "}") == 0) { continue; }
-    if (strcmp(t->children[i]->contents, "{") == 0) { continue; }
     if (strcmp(t->children[i]->tag,  "regex") == 0) { continue; }
     x = lval_add(x, lval_read(t->children[i]));
   }


### PR DESCRIPTION
This is to resolve issue #112 . 'regex' is needed for parsing as it is the main container tag for mpc library. So,  I have removed only lines with curly brackets.

I have compiled s_expressions.c and verified that the examples in the chapter are all working correctly. 