### PR TITLE
atoi converts a char * to an int, not to a long

### DIFF
--- a/chapter7_evaluation.html
+++ b/chapter7_evaluation.html
@@ -126,7 +126,7 @@ printf("First Child Number of children: %i\n",
 <p>To detect the tag of a node, or to get a number from a node, we will need to make use of the <code>tag</code> and <code>contents</code> fields. These are <em>string</em> fields, so we are going to have to learn a couple of string functions first.</p>
 
 <table class='table'>
-  <tr><td><code>atoi</code></td><td>Converts a <code>char*</code> to a <code>long</code>.</td></tr>
+  <tr><td><code>atoi</code></td><td>Converts a <code>char*</code> to an <code>int</code>.</td></tr>
   <tr><td><code>strcmp</code></td><td>Takes as input two <code>char*</code> and if they are equal it returns <code>0</code>.</td></tr>
   <tr><td><code>strstr</code></td><td>Takes as input two <code>char*</code> and returns a pointer to the location of the second in the first, or <code>0</code> if the second is not a sub-string of the first.</td></tr>
 </table>


### PR DESCRIPTION
We can instead use `atol` if we want to convert to a long.