### PR TITLE
Add comment to exclude history.h

### DIFF
--- a/chapter4_interactive_prompt.html
+++ b/chapter4_interactive_prompt.html
@@ -121,6 +121,7 @@ lispy> hel^[[D^[[C
 #include &lt;stdlib.h&gt;
 
 #include &lt;editline/readline.h&gt;
+// Do not include history.h for MacOS X or later
 #include &lt;editline/history.h&gt;
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
##Error##
`REPL.c:4:10: fatal error: 'editline/readline.h' file not found`

##Solution##
There is a common error on including `<editline/history.h>`. The solution is to remove it given many users on MacOS X that doesn't have the lib. 

##Reference##
https://stackoverflow.com/questions/22886475/editline-history-h-and-editline-readline-h-not-found-working-on-osx-when-trying