### PR TITLE
Fix reverse polish conversion

### DIFF
--- a/chapter6_parsing.html
+++ b/chapter6_parsing.html
@@ -14,7 +14,7 @@
 <p>For example...</p>
 
 <table class='table' style='display: inline'>
-  <tr><td><code>1 + 2 + 6</code></td><td><em>is</em></td><td><code>+ 1 2 6</code></td></tr>
+  <tr><td><code>1 + 2 + 6</code></td><td><em>is</em></td><td><code>+ + 1 2 6</code></td></tr>
   <tr><td><code>6 + (2 * 9)</code></td><td><em>is</em></td><td><code>+ 6 (* 2 9)</code></td></tr>
   <tr><td><code>(10 * 2) / (4 + 2)</code></td><td><em>is</em></td><td><code>/ (* 10 2) (+ 4 2)</code></td></tr>
   <tr><td></td><td></td><td></td></tr>


### PR DESCRIPTION
The reverse polish notation equivalent for `1 + 2 + 6` looked off to me, so I checked with: https://raj457036.github.io/Simple-Tools/prefixAndPostfixConvertor.html

Indeed, it should be `+ + 1 2 6` (it is missing an operator)