### PR TITLE
Fix deprecated werkzeug.contrib.cache usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Running
 You can't just browse the raw HTML files of the site. The links wont work, and it wont have a proper header or footer. If you want to run this website locally, you should install Flask and run the website as follows.
 
 ```
-pip install Flask
+pip install Flask cachelib
 python lispy.py
 ```
 

--- a/lispy.py
+++ b/lispy.py
@@ -3,7 +3,7 @@ import logging
 import random
 import datetime
 
-from werkzeug.contrib.cache import MemcachedCache
+from cachelib import MemcachedCache
 from werkzeug.datastructures import ImmutableOrderedMultiDict
 
 from flask import Flask, jsonify, request, send_file, redirect, url_for


### PR DESCRIPTION
It appears that werkzeug.contrib.cache has been deprecated (see:
https://werkzeug.palletsprojects.com/en/0.16.x/contrib/cache/)
and the module is being maintained as a separate entity as cachelib
(see: https://github.com/pallets/cachelib).

This change substitutes calls to werkzeug.contrib.cache with cachelib
and also updates the README.md accordingly.