### PR TITLE
Chapter 4: Cleanup _WIN32 readline() dummy function.

### DIFF
--- a/chapter4_interactive_prompt.html
+++ b/chapter4_interactive_prompt.html
@@ -216,9 +216,8 @@ static char buffer[2048];
 char* readline(char* prompt) {
   fputs(prompt, stdout);
   fgets(buffer, 2048, stdin);
-  char* cpy = malloc(strlen(buffer)+1);
+  char* cpy = malloc(strlen(buffer));
   strcpy(cpy, buffer);
-  cpy[strlen(cpy)-1] = '\0';
   return cpy;
 }
 


### PR DESCRIPTION
1. Allocate only stlen(buffer)-bytes for char* cpy.
2. Remove un-needed addition of '\0' to char* cpy.

Reasons (based on the GNU/Linux man pages):
1. fgets "reads in at most one less than size characters from stream"
2. fgets stores a "... terminating null byte ('\0') ... after the last
   character in the buffer" and strcpy "copies  the string ... includ-
   ing the terminating null byte ('\0')"