### PR TITLE
Chapter 4: Cleanup _WIN32 readline() dummy function.

### DIFF
--- a/chapter4_interactive_prompt.html
+++ b/chapter4_interactive_prompt.html
@@ -218,7 +218,6 @@ char* readline(char* prompt) {
   fgets(buffer, 2048, stdin);
   char* cpy = malloc(strlen(buffer)+1);
   strcpy(cpy, buffer);
-  cpy[strlen(cpy)-1] = '\0';
   return cpy;
 }
 


### PR DESCRIPTION
* Remove un-needed addition of '\0' to char* cpy.

According to GNU/Linux man pages, fgets stores a "... terminating
null byte ('\0') ... after the last character in the buffer" and strcpy
"copies  the string ... including the terminating null byte ('\0')"