### PR TITLE
Refactor def eq handling

### DIFF
--- a/chapter12_functions.html
+++ b/chapter12_functions.html
@@ -286,7 +286,7 @@ lenv_add_builtin(e, "=",   builtin_put);</code></pre>
     "Function '%s' passed too many arguments for symbols. "
     "Got %i, Expected %i.", func, syms-&gt;count, a-&gt;count-1);
 
-  /* If 'def' define in globally. If 'put' define in locally */
+  /* If 'def' define symbol globally. If 'put' define symbol locally */
   if (strcmp(func, "def") == 0) {
       for (int i = 0; i < syms->count; i++) {
           lenv_def(e, syms->cell[i], a->cell[i + 1]);

--- a/chapter12_functions.html
+++ b/chapter12_functions.html
@@ -286,15 +286,15 @@ lenv_add_builtin(e, "=",   builtin_put);</code></pre>
     "Function '%s' passed too many arguments for symbols. "
     "Got %i, Expected %i.", func, syms-&gt;count, a-&gt;count-1);
 
-  for (int i = 0; i &lt; syms-&gt;count; i++) {
-    /* If 'def' define in globally. If 'put' define in locally */
-    if (strcmp(func, "def") == 0) {
-      lenv_def(e, syms-&gt;cell[i], a-&gt;cell[i+1]);
-    }
-
-    if (strcmp(func, "=")   == 0) {
-      lenv_put(e, syms-&gt;cell[i], a-&gt;cell[i+1]);
-    }
+  /* If 'def' define in globally. If 'put' define in locally */
+  if (strcmp(func, "def") == 0) {
+      for (int i = 0; i < syms->count; i++) {
+          lenv_def(e, syms->cell[i], a->cell[i + 1]);
+      }
+  } else if (strcmp(func, "=") == 0) {
+      for (int i = 0; i < syms->count; i++) {
+          lenv_put(e, syms->cell[i], a->cell[i + 1]);
+      }
   }
 
   lval_del(a);

--- a/src/conditionals.c
+++ b/src/conditionals.c
@@ -513,9 +513,14 @@ lval* builtin_var(lenv* e, lval* a, char* func) {
     "Got %i, Expected %i.",
     func, syms->count, a->count-1);
     
-  for (int i = 0; i < syms->count; i++) {
-    if (strcmp(func, "def") == 0) { lenv_def(e, syms->cell[i], a->cell[i+1]); }
-    if (strcmp(func, "=")   == 0) { lenv_put(e, syms->cell[i], a->cell[i+1]); } 
+  if (strcmp(func, "def") == 0) {
+      for (int i = 0; i < syms->count; i++) {
+          lenv_def(e, syms->cell[i], a->cell[i + 1]);
+      }
+  } else if (strcmp(func, "=") == 0) {
+      for (int i = 0; i < syms->count; i++) {
+          lenv_put(e, syms->cell[i], a->cell[i + 1]);
+      }
   }
   
   lval_del(a);

--- a/src/functions.c
+++ b/src/functions.c
@@ -489,7 +489,7 @@ lval* builtin_var(lenv* e, lval* a, char* func) {
     "Function '%s' passed too many arguments for symbols. "
     "Got %i, Expected %i.", func, syms->count, a->count-1);
     
-  /* If 'def' define in globally. If 'put' define in locally */
+  /* If 'def' define symbol globally. If 'put' define symbol locally */
   if (strcmp(func, "def") == 0) {
       for (int i = 0; i < syms->count; i++) {
           lenv_def(e, syms->cell[i], a->cell[i + 1]);

--- a/src/functions.c
+++ b/src/functions.c
@@ -489,15 +489,15 @@ lval* builtin_var(lenv* e, lval* a, char* func) {
     "Function '%s' passed too many arguments for symbols. "
     "Got %i, Expected %i.", func, syms->count, a->count-1);
     
-  for (int i = 0; i < syms->count; i++) {
-    /* If 'def' define in globally. If 'put' define in locally */
-    if (strcmp(func, "def") == 0) {
-      lenv_def(e, syms->cell[i], a->cell[i+1]);
-    }
-    
-    if (strcmp(func, "=")   == 0) {
-      lenv_put(e, syms->cell[i], a->cell[i+1]);
-    } 
+  /* If 'def' define in globally. If 'put' define in locally */
+  if (strcmp(func, "def") == 0) {
+      for (int i = 0; i < syms->count; i++) {
+          lenv_def(e, syms->cell[i], a->cell[i + 1]);
+      }
+  } else if (strcmp(func, "=") == 0) {
+      for (int i = 0; i < syms->count; i++) {
+          lenv_put(e, syms->cell[i], a->cell[i + 1]);
+      }
   }
   
   lval_del(a);

--- a/src/hand_rolled_parser.c
+++ b/src/hand_rolled_parser.c
@@ -578,9 +578,14 @@ lval* builtin_var(lenv* e, lval* a, char* func) {
     "Got %i, Expected %i.",
     func, syms->count, a->count-1);
     
-  for (int i = 0; i < syms->count; i++) {
-    if (strcmp(func, "def") == 0) { lenv_def(e, syms->cell[i], a->cell[i+1]); }
-    if (strcmp(func, "=")   == 0) { lenv_put(e, syms->cell[i], a->cell[i+1]); } 
+  if (strcmp(func, "def") == 0) {
+      for (int i = 0; i < syms->count; i++) {
+          lenv_def(e, syms->cell[i], a->cell[i + 1]);
+      }
+  } else if (strcmp(func, "=") == 0) {
+      for (int i = 0; i < syms->count; i++) {
+          lenv_put(e, syms->cell[i], a->cell[i + 1]);
+      }
   }
   
   lval_del(a);

--- a/src/strings.c
+++ b/src/strings.c
@@ -542,9 +542,14 @@ lval* builtin_var(lenv* e, lval* a, char* func) {
     "Got %i, Expected %i.",
     func, syms->count, a->count-1);
     
-  for (int i = 0; i < syms->count; i++) {
-    if (strcmp(func, "def") == 0) { lenv_def(e, syms->cell[i], a->cell[i+1]); }
-    if (strcmp(func, "=")   == 0) { lenv_put(e, syms->cell[i], a->cell[i+1]); } 
+  if (strcmp(func, "def") == 0) {
+      for (int i = 0; i < syms->count; i++) {
+          lenv_def(e, syms->cell[i], a->cell[i + 1]);
+      }
+  } else if (strcmp(func, "=") == 0) {
+      for (int i = 0; i < syms->count; i++) {
+          lenv_put(e, syms->cell[i], a->cell[i + 1]);
+      }
   }
   
   lval_del(a);


### PR DESCRIPTION
Refactor: move 'def' and '=' handling to outside of the for loop in builtin_var

- Eliminates repeated strcmp calls
- Maintains existing behavior