### PR TITLE
Update mpca_lang() example by add null terminated argument

### DIFF
--- a/chapter10_q_expressions.html
+++ b/chapter10_q_expressions.html
@@ -47,7 +47,7 @@ mpca_lang(MPCA_LANG_DEFAULT,
     expr   : &lt;number&gt; | &lt;symbol&gt; | &lt;sexpr&gt; | &lt;qexpr&gt; ; \
     lispy  : /^/ &lt;expr&gt;* /$/ ;                         \
   ",
-  Number, Symbol, Sexpr, Qexpr, Expr, Lispy);</code></pre>
+  Number, Symbol, Sexpr, Qexpr, Expr, Lispy, NULL);</code></pre>
 
 <p>We also must remember to update our cleanup function to deal with the new rule we've added.</p>
 
@@ -156,7 +156,7 @@ lispy&gt;
     expr   : &lt;number&gt; | &lt;symbol&gt; | &lt;sexpr&gt; | &lt;qexpr&gt; ;     \
     lispy  : /^/ &lt;expr&gt;* /$/ ;                             \
   ",
-  Number, Symbol, Sexpr, Qexpr, Expr, Lispy)
+  Number, Symbol, Sexpr, Qexpr, Expr, Lispy, NULL)
 </code></pre>
 
 

--- a/chapter11_variables.html
+++ b/chapter11_variables.html
@@ -46,7 +46,7 @@
     expr   : &lt;number&gt; | &lt;symbol&gt; | &lt;sexpr&gt; | &lt;qexpr&gt; ;  \
     lispy  : /^/ &lt;expr&gt;* /$/ ;                          \
   ",
-  Number, Symbol, Sexpr, Qexpr, Expr, Lispy);
+  Number, Symbol, Sexpr, Qexpr, Expr, Lispy, NULL);
 </code></pre>
 
 

--- a/chapter14_strings.html
+++ b/chapter14_strings.html
@@ -155,7 +155,7 @@ lispy&gt;</code></pre>
             | &lt;comment&gt; | &lt;sexpr&gt;  | &lt;qexpr&gt;;    \
     lispy   : /^/ &lt;expr&gt;* /$/ ;                  \
   ",
-  Number, Symbol, String, Comment, Sexpr, Qexpr, Expr, Lispy);
+  Number, Symbol, String, Comment, Sexpr, Qexpr, Expr, Lispy, NULL);
 </code></pre>
 
 <p>And the cleanup function looks like this.</p>

--- a/chapter5_languages.html
+++ b/chapter5_languages.html
@@ -125,7 +125,7 @@ mpca_lang(MPCA_LANG_DEFAULT,
     phrase    : &lt;adjective&gt; &lt;noun&gt;;           \
     doge      : &lt;phrase&gt;*;                    \
   ",
-  Adjective, Noun, Phrase, Doge);
+  Adjective, Noun, Phrase, Doge, NULL);
 
 /* Do some parsing here... */
 

--- a/chapter6_parsing.html
+++ b/chapter6_parsing.html
@@ -98,7 +98,7 @@ mpca_lang(MPCA_LANG_DEFAULT,
     expr     : &lt;number&gt; | '(' &lt;operator&gt; &lt;expr&gt;+ ')' ;  \
     lispy    : /^/ &lt;operator&gt; &lt;expr&gt;+ /$/ ;             \
   ",
-  Number, Operator, Expr, Lispy);
+  Number, Operator, Expr, Lispy, NULL);
 </code></pre>
 
 <p>We need to add this to the interactive prompt we started on in chapter 4. Put this code right at the beginning of the <code>main</code> function before we print the <em>Version</em> and <em>Exit</em> information. At the end of our program we also need to delete the parsers when we are done with them. Right before <code>main</code> returns we should place the following clean-up code.</p>

--- a/chapter9_s_expressions.html
+++ b/chapter9_s_expressions.html
@@ -96,7 +96,7 @@ mpca_lang(MPCA_LANG_DEFAULT,
     expr   : &lt;number&gt; | &lt;symbol&gt; | &lt;sexpr&gt; ; \
     lispy  : /^/ &lt;expr&gt;* /$/ ;               \
   ",
-  Number, Symbol, Sexpr, Expr, Lispy);</code></pre>
+  Number, Symbol, Sexpr, Expr, Lispy, NULL);</code></pre>
 
 <p>We should also remember to cleanup these rules on exit.</p>
 

--- a/src/conditionals.c
+++ b/src/conditionals.c
@@ -792,7 +792,7 @@ int main(int argc, char** argv) {
       expr   : <number> | <symbol> | <sexpr> | <qexpr> ;  \
       lispy  : /^/ <expr>* /$/ ;                          \
     ",
-    Number, Symbol, Sexpr, Qexpr, Expr, Lispy);
+    Number, Symbol, Sexpr, Qexpr, Expr, Lispy, NULL);
   
   puts("Lispy Version 0.0.0.0.9");
   puts("Press Ctrl+c to Exit\n");

--- a/src/doge_grammar.c
+++ b/src/doge_grammar.c
@@ -16,7 +16,7 @@ int main(int argc, char** argv) {
       phrase    : <adjective> <noun>;           \
       doge      : <phrase>*;                    \
     ",
-    Adjective, Noun, Phrase, Doge);
+    Adjective, Noun, Phrase, Doge, NULL);
 
   /* Do some parsing here... */
 

--- a/src/error_handling.c
+++ b/src/error_handling.c
@@ -130,7 +130,7 @@ int main(int argc, char** argv) {
       expr     : <number> | '(' <operator> <expr>+ ')' ;  \
       lispy    : /^/ <operator> <expr>+ /$/ ;             \
     ",
-    Number, Operator, Expr, Lispy);
+    Number, Operator, Expr, Lispy, NULL);
   
   puts("Lispy Version 0.0.0.0.4");
   puts("Press Ctrl+c to Exit\n");

--- a/src/evaluation.c
+++ b/src/evaluation.c
@@ -66,7 +66,7 @@ int main(int argc, char** argv) {
       expr     : <number> | '(' <operator> <expr>+ ')' ;  \
       lispy    : /^/ <operator> <expr>+ /$/ ;             \
     ",
-    Number, Operator, Expr, Lispy);
+    Number, Operator, Expr, Lispy, NULL);
   
   puts("Lispy Version 0.0.0.0.3");
   puts("Press Ctrl+c to Exit\n");

--- a/src/functions.c
+++ b/src/functions.c
@@ -719,7 +719,7 @@ int main(int argc, char** argv) {
       expr   : <number> | <symbol> | <sexpr> | <qexpr> ;  \
       lispy  : /^/ <expr>* /$/ ;                          \
     ",
-    Number, Symbol, Sexpr, Qexpr, Expr, Lispy);
+    Number, Symbol, Sexpr, Qexpr, Expr, Lispy, NULL);
   
   puts("Lispy Version 0.0.0.0.8");
   puts("Press Ctrl+c to Exit\n");

--- a/src/parsing.c
+++ b/src/parsing.c
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
       expr     : <number> | '(' <operator> <expr>+ ')' ;  \
       lispy    : /^/ <operator> <expr>+ /$/ ;             \
     ",
-    Number, Operator, Expr, Lispy);
+    Number, Operator, Expr, Lispy, NULL);
   
   puts("Lispy Version 0.0.0.0.2");
   puts("Press Ctrl+c to Exit\n");

--- a/src/q_expressions.c
+++ b/src/q_expressions.c
@@ -340,7 +340,7 @@ int main(int argc, char** argv) {
       expr   : <number> | <symbol> | <sexpr> | <qexpr> ; \
       lispy  : /^/ <expr>* /$/ ;                         \
     ",
-    Number, Symbol, Sexpr, Qexpr, Expr, Lispy);
+    Number, Symbol, Sexpr, Qexpr, Expr, Lispy, NULL);
   
   puts("Lispy Version 0.0.0.0.6");
   puts("Press Ctrl+c to Exit\n");

--- a/src/s_expressions.c
+++ b/src/s_expressions.c
@@ -281,7 +281,7 @@ int main(int argc, char** argv) {
       expr   : <number> | <symbol> | <sexpr> ; \
       lispy  : /^/ <expr>* /$/ ;               \
     ",
-    Number, Symbol, Sexpr, Expr, Lispy);
+    Number, Symbol, Sexpr, Expr, Lispy, NULL);
   
   puts("Lispy Version 0.0.0.0.5");
   puts("Press Ctrl+c to Exit\n");

--- a/src/strings.c
+++ b/src/strings.c
@@ -886,7 +886,7 @@ int main(int argc, char** argv) {
               | <comment> | <sexpr>  | <qexpr>;    \
       lispy   : /^/ <expr>* /$/ ;                  \
     ",
-    Number, Symbol, String, Comment, Sexpr, Qexpr, Expr, Lispy);
+    Number, Symbol, String, Comment, Sexpr, Qexpr, Expr, Lispy, NULL);
   
   lenv* e = lenv_new();
   lenv_add_builtins(e);

--- a/src/variables.c
+++ b/src/variables.c
@@ -570,7 +570,7 @@ int main(int argc, char** argv) {
       expr   : <number> | <symbol> | <sexpr> | <qexpr> ;  \
       lispy  : /^/ <expr>* /$/ ;                          \
     ",
-    Number, Symbol, Sexpr, Qexpr, Expr, Lispy);
+    Number, Symbol, Sexpr, Qexpr, Expr, Lispy, NULL);
   
   puts("Lispy Version 0.0.0.0.7");
   puts("Press Ctrl+c to Exit\n");


### PR DESCRIPTION
First of all, thank you for the book. This book help me a lot when i am trying to learn C, especially looking at the mpc parser source code (even though i still have no idea for the majority of the code 😅).

In the current version of mpc parser, we can add `NULL` at the end of arguments mpca_lang() to indicate that it's the end of argument when trying to find parser and prevent segfault error.

This changes update the snippet for the web version and example that use mpca_lang() by adding `NULL` at the end of mpca_lang() argument.

This changes also resolves issue https://github.com/orangeduck/BuildYourOwnLisp/issues/147.